### PR TITLE
Atomic with different content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	</parent>
 
 	<artifactId>digipost-api-client-java</artifactId>
-	<version>6.9-SNAPSHOT</version>
+	<version>6.10</version>
 	<name>Digipost API Client</name>
 	<description>Java library for interacting with the Digipost REST API</description>
 

--- a/src/main/java/no/digipost/api/client/DocumentsPreparer.java
+++ b/src/main/java/no/digipost/api/client/DocumentsPreparer.java
@@ -15,6 +15,7 @@
  */
 package no.digipost.api.client;
 
+import no.digipost.api.client.delivery.DocumentContent;
 import no.digipost.api.client.errorhandling.DigipostClientException;
 import no.digipost.api.client.errorhandling.ErrorCode;
 import no.digipost.api.client.pdf.BlankPdf;
@@ -62,6 +63,10 @@ class DocumentsPreparer {
 			Encrypter encrypter, Fn0<PdfValidationSettings> pdfValidationSettings) throws IOException {
 
 		final Map<Document, InputStream> prepared = new LinkedHashMap<>();
+
+		if(message.recipient.hasPrintDetails() && message.recipient.hasDigipostIdentification()){
+			throw new IllegalStateException("Forventet message med enkelt kanal");
+		}
 
 		for (Elem<Document> i : on(on(documentsAndContent.keySet()).sorted(message.documentOrder())).indexed()) {
 			Document document = i.value;

--- a/src/main/java/no/digipost/api/client/MessageSender.java
+++ b/src/main/java/no/digipost/api/client/MessageSender.java
@@ -312,7 +312,7 @@ public class MessageSender extends Communicator {
 		Message singleChannelMessage;
 
 			if (message.isDirectPrint()) {
-				singleChannelMessage = message;
+				singleChannelMessage = Message.copyMessageWithOnlyPrintDetails(message);
 				mapToPrintContent(documentsAndContent, documentsAndInputstream);
 
 				if (message.hasAnyDocumentRequiringPreEncryption()) {
@@ -347,7 +347,7 @@ public class MessageSender extends Communicator {
 	private static void mapToPrintContent(Map<Document, DocumentContent> documentsAndContent,
 										  Map<Document, InputStream> documentsAndInputstream){
 		for(Entry<Document, DocumentContent> entry : documentsAndContent.entrySet()) {
-			documentsAndInputstream.put(entry.getKey(), entry.getValue().getPrintContent());
+			documentsAndInputstream.put(Document.copyDocumentAndSetDigipostFileTypeToPdf(entry.getKey()), entry.getValue().getPrintContent());
 		}
 	}
 

--- a/src/main/java/no/digipost/api/client/delivery/AtomicPrintOnlyMessage.java
+++ b/src/main/java/no/digipost/api/client/delivery/AtomicPrintOnlyMessage.java
@@ -32,7 +32,7 @@ final class AtomicPrintOnlyMessage implements OngoingDelivery.SendableForPrintOn
 
 	private final MessageSender sender;
 	private final Message printMessage;
-	private final Map<Document, DocumentContent> documents = new LinkedHashMap<>();
+	private final Map<String, DocumentContent> documents = new LinkedHashMap<>();
 
 
     AtomicPrintOnlyMessage(Message printMessage, MessageSender sender) {
@@ -52,7 +52,7 @@ final class AtomicPrintOnlyMessage implements OngoingDelivery.SendableForPrintOn
      */
     @Override
     public AtomicPrintOnlyMessage addContent(Document document, InputStream content) {
-    	documents.put(document, DocumentContent.CreatePrintContent(content));
+    	documents.put(document.uuid, DocumentContent.CreatePrintContent(content));
     	return this;
     }
 

--- a/src/main/java/no/digipost/api/client/delivery/AtomicPrintOnlyMessage.java
+++ b/src/main/java/no/digipost/api/client/delivery/AtomicPrintOnlyMessage.java
@@ -32,7 +32,7 @@ final class AtomicPrintOnlyMessage implements OngoingDelivery.SendableForPrintOn
 
 	private final MessageSender sender;
 	private final Message printMessage;
-	private final Map<Document, InputStream> documents = new LinkedHashMap<>();
+	private final Map<Document, DocumentContent> documents = new LinkedHashMap<>();
 
 
     AtomicPrintOnlyMessage(Message printMessage, MessageSender sender) {
@@ -52,7 +52,7 @@ final class AtomicPrintOnlyMessage implements OngoingDelivery.SendableForPrintOn
      */
     @Override
     public AtomicPrintOnlyMessage addContent(Document document, InputStream content) {
-    	documents.put(document, content);
+    	documents.put(document, DocumentContent.CreatePrintContent(content));
     	return this;
     }
 

--- a/src/main/java/no/digipost/api/client/delivery/AtomicWithPrintFallback.java
+++ b/src/main/java/no/digipost/api/client/delivery/AtomicWithPrintFallback.java
@@ -34,7 +34,7 @@ final class AtomicWithPrintFallback implements OngoingDelivery.SendableWithPrint
 
 	private final MessageSender sender;
 	private final Message message;
-	private final Map<Document, DocumentContent> documents = new LinkedHashMap<>();
+	private final Map<String, DocumentContent> documents = new LinkedHashMap<>();
 
     AtomicWithPrintFallback(Message message, MessageSender sender) {
     	this.message = message;
@@ -49,13 +49,13 @@ final class AtomicWithPrintFallback implements OngoingDelivery.SendableWithPrint
      */
 	@Override
 	public OngoingDelivery.SendableWithPrintFallback addContent(Document document, InputStream content) {
-		documents.put(document, DocumentContent.CreateBothStreamContent(content));
+		documents.put(document.uuid, DocumentContent.CreateBothStreamContent(content));
 		return this;
 	}
 
 	@Override
 	public OngoingDelivery.SendableWithPrintFallback addContent(Document document, InputStream content, InputStream printContent) {
-		documents.put(document, DocumentContent.CreateMultiStreamContent(content, printContent));
+		documents.put(document.uuid, DocumentContent.CreateMultiStreamContent(content, printContent));
 		return this;
 	}
 

--- a/src/main/java/no/digipost/api/client/delivery/AtomicWithPrintFallback.java
+++ b/src/main/java/no/digipost/api/client/delivery/AtomicWithPrintFallback.java
@@ -34,7 +34,7 @@ final class AtomicWithPrintFallback implements OngoingDelivery.SendableWithPrint
 
 	private final MessageSender sender;
 	private final Message message;
-	private final Map<Document, InputStream> documents = new LinkedHashMap<>();
+	private final Map<Document, DocumentContent> documents = new LinkedHashMap<>();
 
     AtomicWithPrintFallback(Message message, MessageSender sender) {
     	this.message = message;
@@ -47,28 +47,20 @@ final class AtomicWithPrintFallback implements OngoingDelivery.SendableWithPrint
      *
      * @return videre operasjoner for å fullføre leveransen.
      */
-    @Override
-    public OngoingDelivery.SendableWithPrintFallback addContent(Document document, InputStream content) {
-    	documents.put(document, content);
-    	return this;
-    }
+	@Override
+	public OngoingDelivery.SendableWithPrintFallback addContent(Document document, InputStream content) {
+		documents.put(document, DocumentContent.CreateBothStreamContent(content));
+		return this;
+	}
 
-
-    @Override
-    public OngoingDelivery.SendableWithPrintFallback addContent(Document document, InputStream content, InputStream printContent) {
-    	if (printContent == null) {
-    		return addContent(document, content);
-    	} else {
-    		throw new UnsupportedOperationException(
-    				"Adding separate content for print is not supported for " +
-					ApiFlavor.class.getSimpleName() + " " + ApiFlavor.ATOMIC_REST);
-    	}
-    }
-
+	@Override
+	public OngoingDelivery.SendableWithPrintFallback addContent(Document document, InputStream content, InputStream printContent) {
+		documents.put(document, DocumentContent.CreateMultiStreamContent(content, printContent));
+		return this;
+	}
 
 	@Override
     public MessageDelivery send() {
 		return sender.sendMultipartMessage(message, documents);
     }
-
 }

--- a/src/main/java/no/digipost/api/client/delivery/DocumentContent.java
+++ b/src/main/java/no/digipost/api/client/delivery/DocumentContent.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.delivery;
+
+import java.io.InputStream;
+
+public class DocumentContent {
+	private final InputStream digipostContent;
+	private final InputStream printContent;
+
+	private DocumentContent(InputStream digipostContent, InputStream printContent){
+		this.digipostContent = digipostContent;
+		this.printContent = printContent;
+	}
+
+	public InputStream getPrintContent(){
+		if(printContent == null){
+			throw new IllegalAccessError("Content ikke tilgjengelig, dette er et digipost DocumentContent");
+		}
+
+		return printContent;
+	}
+
+	public InputStream getDigipostContent(){
+		if(digipostContent == null){
+			throw new IllegalAccessError("Content ikke tilgjengelig, dette er et print DocumentContent");
+		}
+
+		return digipostContent;
+	}
+
+	public static DocumentContent CreateDigiPostContent(InputStream content){
+		return new DocumentContent(content, null);
+	}
+
+	public static DocumentContent CreatePrintContent(InputStream content){
+		return new DocumentContent(null, content);
+	}
+
+	public static DocumentContent CreateMultiStreamContent(InputStream digipostContent, InputStream printContent){
+		return new DocumentContent(digipostContent, printContent);
+	}
+
+	public static DocumentContent CreateBothStreamContent(InputStream content){
+		return new DocumentContent(content, content);
+	}
+}

--- a/src/main/java/no/digipost/api/client/representations/Document.java
+++ b/src/main/java/no/digipost/api/client/representations/Document.java
@@ -119,6 +119,21 @@ public class Document extends Representation {
 		validate();
 	}
 
+	public static Document copyDocumentAndSetDigipostFileTypeToPdf(Document doc){
+		Document newDoc = new Document(doc.uuid, doc.subject, new FileType("pdf"), doc.openingReceipt, doc.smsNotification, doc.emailNotification,
+				doc.authenticationLevel, doc.sensitivityLevel, doc.opened, doc.getTechnicalType());
+
+		if(doc.getPreEncryptNoPages() != null) {
+			newDoc.setNoEncryptedPages(doc.getPreEncryptNoPages());
+		}
+		if(doc.preEncrypt != null && doc.preEncrypt){
+			newDoc.setPreEncrypt();
+		}
+		newDoc.setContentHash(doc.contentHash);
+
+		return newDoc;
+	}
+
 	private void validate() {
 		List<String> errors = new ArrayList<>();
 		if (uuid != null && !UUID_PATTERN.matcher(this.uuid).matches()) {
@@ -138,6 +153,10 @@ public class Document extends Representation {
 		Document document = new Document(UUID.randomUUID().toString(), null, fileType);
 		document.technicalType = type;
 		return document;
+	}
+
+	public void setContentHash(ContentHash contentHash){
+		this.contentHash = contentHash;
 	}
 
 	public void setDigipostFileType(FileType fileType) {

--- a/src/main/java/no/digipost/api/client/representations/IdentificationResultWithEncryptionKey.java
+++ b/src/main/java/no/digipost/api/client/representations/IdentificationResultWithEncryptionKey.java
@@ -44,6 +44,10 @@ public class IdentificationResultWithEncryptionKey {
 		return result;
 	}
 
+	public IdentificationResultCode getResultCode(){
+		return result.getResult();
+	}
+
 	public EncryptionKey getEncryptionKey() {
 		return encryptionKey;
 	}

--- a/src/main/java/no/digipost/api/client/representations/Message.java
+++ b/src/main/java/no/digipost/api/client/representations/Message.java
@@ -18,6 +18,7 @@ package no.digipost.api.client.representations;
 import no.digipost.api.client.representations.xml.DateTimeXmlAdapter;
 import org.joda.time.DateTime;
 
+import javax.print.Doc;
 import javax.xml.bind.annotation.*;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
@@ -181,16 +182,21 @@ public class Message implements MayHaveSender {
 	}
 
 	public static Message copyMessageWithOnlyPrintDetails(Message messageToCopy){
+		List<Document> tmpAttachments = new ArrayList<>();
+		for(Document attachment : messageToCopy.attachments){
+			tmpAttachments.add(copyDocumentAndSetFiletypeToPdf(attachment));
+		}
+
 		return new Message(messageToCopy.messageId, messageToCopy.senderId, messageToCopy.senderOrganization,
-				null, null, null, null, messageToCopy.deliveryTime, messageToCopy.invoiceReference, messageToCopy.primaryDocument,
-				messageToCopy.attachments, messageToCopy.recipient.getPrintDetails());
+				null, null, null, null, messageToCopy.deliveryTime, messageToCopy.invoiceReference,
+				copyDocumentAndSetFiletypeToPdf(messageToCopy.primaryDocument), tmpAttachments, messageToCopy.recipient.getPrintDetails());
 	}
 
 	public static Message copyMessageWithOnlyDigipostDetails(Message messageToCopy){
 		return new Message(messageToCopy.messageId, messageToCopy.senderId, messageToCopy.senderOrganization,
 				messageToCopy.recipient.nameAndAddress, messageToCopy.recipient.digipostAddress,
-				messageToCopy.recipient.personalIdentificationNumber, messageToCopy.recipient.organisationNumber
-				, messageToCopy.deliveryTime, messageToCopy.invoiceReference, messageToCopy.primaryDocument,
+				messageToCopy.recipient.personalIdentificationNumber, messageToCopy.recipient.organisationNumber,
+				messageToCopy.deliveryTime, messageToCopy.invoiceReference, messageToCopy.primaryDocument,
 				messageToCopy.attachments, null);
 	}
 
@@ -208,6 +214,12 @@ public class Message implements MayHaveSender {
 		this.invoiceReference = invoiceReference;
 		this.primaryDocument = primaryDocument;
 		this.attachments = attachments;
+	}
+
+	private static Document copyDocumentAndSetFiletypeToPdf(Document documentToCopy){
+		return new Document(documentToCopy.uuid, documentToCopy.subject, new FileType("PDF"), documentToCopy.openingReceipt,
+				documentToCopy.smsNotification, documentToCopy.emailNotification, documentToCopy.authenticationLevel,
+				documentToCopy.sensitivityLevel, documentToCopy.opened, documentToCopy.getTechnicalType());
 	}
 
 

--- a/src/main/java/no/digipost/api/client/representations/Message.java
+++ b/src/main/java/no/digipost/api/client/representations/Message.java
@@ -180,6 +180,37 @@ public class Message implements MayHaveSender {
         }
 	}
 
+	public static Message copyMessageWithOnlyPrintDetails(Message messageToCopy){
+		return new Message(messageToCopy.messageId, messageToCopy.senderId, messageToCopy.senderOrganization,
+				null, null, null, null, messageToCopy.deliveryTime, messageToCopy.invoiceReference, messageToCopy.primaryDocument,
+				messageToCopy.attachments, messageToCopy.recipient.getPrintDetails());
+	}
+
+	public static Message copyMessageWithOnlyDigipostDetails(Message messageToCopy){
+		return new Message(messageToCopy.messageId, messageToCopy.senderId, messageToCopy.senderOrganization,
+				messageToCopy.recipient.nameAndAddress, messageToCopy.recipient.digipostAddress,
+				messageToCopy.recipient.personalIdentificationNumber, messageToCopy.recipient.organisationNumber
+				, messageToCopy.deliveryTime, messageToCopy.invoiceReference, messageToCopy.primaryDocument,
+				messageToCopy.attachments, null);
+	}
+
+	private Message(final String messageId, final Long senderId, final SenderOrganization senderOrganization,
+					final NameAndAddress nameAndAddress, final String digipostAddress, String personalIdentificationNumber,
+					final String organisationNumber, final DateTime deliveryTime, final String invoiceReference,
+					final Document primaryDocument, final List<Document> attachments, final PrintDetails printDetails){
+		this.messageId = messageId;
+		this.senderId = senderId;
+		this.senderOrganization = senderOrganization;
+		MessageRecipient recipient = new MessageRecipient(nameAndAddress, digipostAddress,
+				personalIdentificationNumber, organisationNumber, printDetails);
+		this.recipient = recipient;
+		this.deliveryTime = deliveryTime;
+		this.invoiceReference = invoiceReference;
+		this.primaryDocument = primaryDocument;
+		this.attachments = attachments;
+	}
+
+
 	/**
 	 * @return a list containing every {@link Document} in this delivery.
 	 *         The primary document will be the first element of the list,

--- a/src/main/java/no/digipost/api/client/representations/Message.java
+++ b/src/main/java/no/digipost/api/client/representations/Message.java
@@ -184,12 +184,12 @@ public class Message implements MayHaveSender {
 	public static Message copyMessageWithOnlyPrintDetails(Message messageToCopy){
 		List<Document> tmpAttachments = new ArrayList<>();
 		for(Document attachment : messageToCopy.attachments){
-			tmpAttachments.add(copyDocumentAndSetFiletypeToPdf(attachment));
+			tmpAttachments.add(Document.copyDocumentAndSetDigipostFileTypeToPdf(attachment));
 		}
 
 		return new Message(messageToCopy.messageId, messageToCopy.senderId, messageToCopy.senderOrganization,
 				null, null, null, null, messageToCopy.deliveryTime, messageToCopy.invoiceReference,
-				copyDocumentAndSetFiletypeToPdf(messageToCopy.primaryDocument), tmpAttachments, messageToCopy.recipient.getPrintDetails());
+				Document.copyDocumentAndSetDigipostFileTypeToPdf(messageToCopy.primaryDocument), tmpAttachments, messageToCopy.recipient.getPrintDetails());
 	}
 
 	public static Message copyMessageWithOnlyDigipostDetails(Message messageToCopy){
@@ -214,12 +214,6 @@ public class Message implements MayHaveSender {
 		this.invoiceReference = invoiceReference;
 		this.primaryDocument = primaryDocument;
 		this.attachments = attachments;
-	}
-
-	private static Document copyDocumentAndSetFiletypeToPdf(Document documentToCopy){
-		return new Document(documentToCopy.uuid, documentToCopy.subject, new FileType("PDF"), documentToCopy.openingReceipt,
-				documentToCopy.smsNotification, documentToCopy.emailNotification, documentToCopy.authenticationLevel,
-				documentToCopy.sensitivityLevel, documentToCopy.opened, documentToCopy.getTechnicalType());
 	}
 
 

--- a/src/main/java/no/digipost/api/client/representations/MessageRecipient.java
+++ b/src/main/java/no/digipost/api/client/representations/MessageRecipient.java
@@ -47,6 +47,15 @@ public class MessageRecipient {
 	public MessageRecipient() {
 	}
 
+	MessageRecipient(NameAndAddress nameAndAddress, String digipostAddress, String personalIdentificationNumber,
+							String organisationNumber, PrintDetails printDetails){
+		this.nameAndAddress = nameAndAddress;
+		this.digipostAddress = digipostAddress;
+		this.personalIdentificationNumber = personalIdentificationNumber;
+		this.organisationNumber = organisationNumber;
+		this.printDetails = printDetails;
+	}
+
 	public MessageRecipient(final PersonalIdentificationNumber id) {
 		this.personalIdentificationNumber = id.asString();
 	}

--- a/src/test/java/no/digipost/api/client/MessageSenderTest.java
+++ b/src/test/java/no/digipost/api/client/MessageSenderTest.java
@@ -16,7 +16,9 @@
 package no.digipost.api.client;
 
 import no.digipost.api.client.delivery.ApiFlavor;
+import no.digipost.api.client.delivery.DocumentContent;
 import no.digipost.api.client.delivery.MessageDeliverer;
+import no.digipost.api.client.delivery.OngoingDelivery;
 import no.digipost.api.client.delivery.OngoingDelivery.SendableForPrintOnly;
 import no.digipost.api.client.errorhandling.DigipostClientException;
 import no.digipost.api.client.errorhandling.ErrorCode;
@@ -24,6 +26,8 @@ import no.digipost.api.client.representations.*;
 import no.digipost.api.client.representations.sender.SenderInformation;
 import no.digipost.api.client.security.CryptoUtil;
 import no.digipost.api.client.util.MockfriendlyResponse;
+import no.digipost.print.validate.PdfValidationError;
+import no.digipost.print.validate.PdfValidationResult;
 import no.digipost.print.validate.PdfValidationSettings;
 import no.digipost.print.validate.PdfValidator;
 import org.glassfish.jersey.media.multipart.MultiPart;
@@ -34,6 +38,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
@@ -44,8 +49,7 @@ import javax.ws.rs.core.Response.Status;
 
 import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 import static java.util.Arrays.asList;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
@@ -54,6 +58,7 @@ import static no.digipost.api.client.delivery.ApiFlavor.ATOMIC_REST;
 import static no.digipost.api.client.delivery.ApiFlavor.STEPWISE_REST;
 import static no.digipost.api.client.pdf.EksempelPdf.pdf20Pages;
 import static no.digipost.api.client.pdf.EksempelPdf.printablePdf1Page;
+import static no.digipost.api.client.pdf.EksempelPdf.printablePdf2Pages;
 import static no.digipost.api.client.representations.AuthenticationLevel.PASSWORD;
 import static no.digipost.api.client.representations.Channel.DIGIPOST;
 import static no.digipost.api.client.representations.Channel.PRINT;
@@ -90,6 +95,9 @@ public class MessageSenderTest {
 
 	@Mock
 	private ApiService api;
+
+	@Mock
+	IdentificationResultWithEncryptionKey identificationResultWithEncryptionKey;
 
 	private MockfriendlyResponse encryptionKeyResponse;
 
@@ -185,6 +193,47 @@ public class MessageSenderTest {
 		DateTimeUtils.setCurrentMillisOffset(Duration.standardMinutes(10).getMillis());
 		sender.getEncryptionKeyForPrint();
 		then(api).should(times(2)).getEncryptionKeyForPrint();
+	}
+
+	@Test
+	public void fallback_to_print_changes_filetype_html_to_pdf() {
+		when(identificationResultWithEncryptionKey.getResult()).thenReturn(new IdentificationResult());
+		when(mockClientResponse.getStatus()).thenReturn(200);
+		when(mockClientResponse.readEntity(IdentificationResultWithEncryptionKey.class)).thenReturn(identificationResultWithEncryptionKey);
+
+		SenderInformation senderInformation = Mockito.mock(SenderInformation.class);
+		when(senderInformation.getPdfValidationSettings()).thenReturn(new PdfValidationSettings(false, false, true, false));
+
+		when(api.getEncryptionKey(any(URI.class))).thenReturn(encryptionKeyResponse);
+		when(api.getEncryptionKeyForPrint()).thenReturn(encryptionKeyResponse);
+		when(api.identifyAndGetEncryptionKey(any(Identification.class))).thenReturn(mockClientResponse);
+		when(api.getSenderInformation(any(Message.class))).thenReturn(senderInformation);
+
+		Response response = Mockito.mock(Response.class);
+		when(response.getEntity()).thenReturn(new Object());
+		when(response.getStatus()).thenReturn(200);
+		when(response.readEntity(Object.class)).thenReturn(new Object());
+
+		when(api.multipartMessage(any(MultiPart.class))).thenReturn(response);
+
+		String messageId = UUID.randomUUID().toString();
+		final Document printDocument = new Document(UUID.randomUUID().toString(), "subject", FileType.HTML).setPreEncrypt();
+		final List<Document> printAttachments = asList(new Document(UUID.randomUUID().toString(), "attachment", FileType.HTML).setPreEncrypt());
+		PrintRecipient recipient = new PrintRecipient("Rallhild Ralleberg", new NorwegianAddress("0560", "Oslo"));
+		PrintRecipient returnAddress = new PrintRecipient("Megacorp", new NorwegianAddress("0105", "Oslo"));
+
+		Map<Document, DocumentContent> documentAndContent = new LinkedHashMap<>();
+
+		MessageSender messageSender = new MessageSender(api, DigipostClient.NOOP_EVENT_LOGGER, pdfValidator);
+		Message message = newMessage(messageId, printDocument).attachments(printAttachments)
+				.recipient(new MessageRecipient(new DigipostAddress("asdfasd"), new PrintDetails(recipient, returnAddress, A))).build();
+
+		documentAndContent.put(message.primaryDocument, DocumentContent.CreateBothStreamContent(printablePdf1Page()));
+		for (Document attachment : printAttachments) {
+			documentAndContent.put(attachment, DocumentContent.CreateBothStreamContent(printablePdf1Page()));
+		}
+
+		messageSender.sendMultipartMessage(message, documentAndContent);
 	}
 
 	@Test

--- a/src/test/java/no/digipost/api/client/representations/DocumentTest.java
+++ b/src/test/java/no/digipost/api/client/representations/DocumentTest.java
@@ -60,6 +60,7 @@ public class DocumentTest {
 				new EmailNotification("ny@gmail.com", "Detta", "Er", new ArrayList<ListedTime>()), AuthenticationLevel.IDPORTEN_3,
 				SensitivityLevel.NORMAL, false, "technicalType");
 
+
 		Document copyOfDoc = Document.copyDocumentAndSetDigipostFileTypeToPdf(originalDoc);
 
 		assertThat(originalDoc.digipostFileType, is(HTML.toString()));

--- a/src/test/java/no/digipost/api/client/representations/DocumentTest.java
+++ b/src/test/java/no/digipost/api/client/representations/DocumentTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.representations;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import javax.xml.parsers.DocumentBuilder;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.UUID;
+
+import static no.digipost.api.client.representations.FileType.HTML;
+import static no.digipost.api.client.representations.FileType.PDF;
+import static no.digipost.api.client.representations.Message.MessageBuilder.newMessage;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+public class DocumentTest {
+
+	@Test
+	public void assertThatDocumentClassHaveNotBeenChangedWithoutChangingDocumentCopyMethod() {
+		Field[] messageFields = Document.class.getDeclaredFields();
+		assertThat(messageFields.length, is(17));
+
+		String[] allFieldsThatAreUsedForCopyInMessage = new String[]{"UUID_PATTERN", "uuid", "subject", "digipostFileType",
+				"opened", "openingReceipt", "smsNotification", "emailNotification", "authenticationLevel", "sensitivityLevel",
+				"preEncrypt", "preEncryptNoPages", "contentHash", "technicalType", "isPreEncrypt", "getUuid", "getFileType"};
+
+		for(int i = 0; i < messageFields.length; i++){
+			for(int n = 0; n < allFieldsThatAreUsedForCopyInMessage.length; n++){
+				if(messageFields[i].getName().equals(allFieldsThatAreUsedForCopyInMessage[n])){
+					allFieldsThatAreUsedForCopyInMessage[n] = "";
+				}
+			}
+		}
+
+		for(String shouldBeEmpty : allFieldsThatAreUsedForCopyInMessage){
+			assertThat(shouldBeEmpty, is(""));
+		}
+	}
+
+	@Test
+	public void copyOfMessageIsTheSameAsTheOriginalExceptPrintDetails() {
+		Document originalDoc = new Document(UUID.randomUUID().toString(), "ThisIsASubject", HTML, "OpeningReceipt", new SmsNotification(1),
+				new EmailNotification("ny@gmail.com", "Detta", "Er", new ArrayList<ListedTime>()), AuthenticationLevel.IDPORTEN_3,
+				SensitivityLevel.NORMAL, false, "technicalType");
+
+		Document copyOfDoc = Document.copyDocumentAndSetDigipostFileTypeToPdf(originalDoc);
+
+		assertThat(originalDoc.digipostFileType, is(HTML.toString()));
+		assertThat(copyOfDoc.digipostFileType, is(PDF.toString()));
+		assertThat(originalDoc.authenticationLevel, is(copyOfDoc.authenticationLevel));
+		assertThat(originalDoc.contentHash, is(copyOfDoc.contentHash));
+		assertThat(originalDoc.emailNotification, is(copyOfDoc.emailNotification));
+		assertThat(originalDoc.opened, is(copyOfDoc.opened));
+		assertThat(originalDoc.openingReceipt, is(copyOfDoc.openingReceipt));
+		assertThat(originalDoc.preEncrypt, is(copyOfDoc.preEncrypt));
+		assertThat(originalDoc.preEncryptNoPages, is(copyOfDoc.preEncryptNoPages));
+		assertThat(originalDoc.sensitivityLevel, is(copyOfDoc.sensitivityLevel));
+		assertThat(originalDoc.smsNotification, is(copyOfDoc.smsNotification));
+		assertThat(originalDoc.subject, is(copyOfDoc.subject));
+		assertThat(originalDoc.uuid, is(copyOfDoc.uuid));
+		assertThat(originalDoc.links, is(copyOfDoc.links));
+	}
+}

--- a/src/test/java/no/digipost/api/client/representations/MessageTest.java
+++ b/src/test/java/no/digipost/api/client/representations/MessageTest.java
@@ -87,7 +87,7 @@ public class MessageTest {
 
 	@Test
 	public void copyOfMessageIsTheSameAsTheOriginalExceptPrintDetails() {
-		Message message = newMessage(UUID.randomUUID().toString(), new Document(UUID.randomUUID().toString(), "subject", PDF))
+		Message message = newMessage(UUID.randomUUID().toString(), new Document(UUID.randomUUID().toString(), "subject", HTML))
 				.digipostAddress(new DigipostAddress("Test2"))
 				.senderId(1L).deliveryTime(DateTime.now()).invoiceReference("Invoice")
 				.recipient(new MessageRecipient(new DigipostAddress("TestAdress"), new PrintDetails(
@@ -95,32 +95,44 @@ public class MessageTest {
 						, new PrintRecipient("Test", new NorwegianAddress("Bajs", "Korv", "Zip", "Zop")),
 						PrintDetails.PostType.A, PrintDetails.PrintColors.COLORS, PrintDetails.NondeliverableHandling.RETURN_TO_SENDER))).build();
 
-		Message copyOfMessageWithoutDigipostDetails = Message.copyMessageWithOnlyPrintDetails(message);
+		Message copyOfMessageWithPrintDetailsOnly = Message.copyMessageWithOnlyPrintDetails(message);
 
-		assertThat(copyOfMessageWithoutDigipostDetails.deliveryTime, is(message.deliveryTime));
-		assertThat(copyOfMessageWithoutDigipostDetails.invoiceReference, is(message.invoiceReference));
-		assertThat(copyOfMessageWithoutDigipostDetails.messageId, is(message.messageId));
-		assertThat(copyOfMessageWithoutDigipostDetails.senderId, is(message.senderId));
-		assertNull(copyOfMessageWithoutDigipostDetails.recipient.digipostAddress);
-		assertNull(copyOfMessageWithoutDigipostDetails.recipient.nameAndAddress);
-		assertNull(copyOfMessageWithoutDigipostDetails.recipient.organisationNumber);
-		assertNull(copyOfMessageWithoutDigipostDetails.recipient.personalIdentificationNumber);
-		assertThat(copyOfMessageWithoutDigipostDetails.recipient.printDetails.nondeliverableHandling, is(message.recipient.printDetails.nondeliverableHandling));
-		assertThat(copyOfMessageWithoutDigipostDetails.recipient.printDetails.postType, is(message.recipient.printDetails.postType));
-		assertThat(copyOfMessageWithoutDigipostDetails.recipient.printDetails.printColors, is(message.recipient.printDetails.printColors));
-		assertThat(copyOfMessageWithoutDigipostDetails.recipient.printDetails.recipient.name, is(message.recipient.printDetails.recipient.name));
-		assertThat(copyOfMessageWithoutDigipostDetails.recipient.printDetails.recipient.norwegianAddress.addressline1, is(message.recipient.printDetails.recipient.norwegianAddress.addressline1));
+		assertThat(copyOfMessageWithPrintDetailsOnly.deliveryTime, is(message.deliveryTime));
+		assertThat(copyOfMessageWithPrintDetailsOnly.invoiceReference, is(message.invoiceReference));
+		assertThat(copyOfMessageWithPrintDetailsOnly.messageId, is(message.messageId));
+		assertThat(copyOfMessageWithPrintDetailsOnly.senderId, is(message.senderId));
+		assertNull(copyOfMessageWithPrintDetailsOnly.recipient.digipostAddress);
+		assertNull(copyOfMessageWithPrintDetailsOnly.recipient.nameAndAddress);
+		assertNull(copyOfMessageWithPrintDetailsOnly.recipient.organisationNumber);
+		assertNull(copyOfMessageWithPrintDetailsOnly.recipient.personalIdentificationNumber);
+		assertThat(copyOfMessageWithPrintDetailsOnly.recipient.printDetails.nondeliverableHandling, is(message.recipient.printDetails.nondeliverableHandling));
+		assertThat(copyOfMessageWithPrintDetailsOnly.recipient.printDetails.postType, is(message.recipient.printDetails.postType));
+		assertThat(copyOfMessageWithPrintDetailsOnly.recipient.printDetails.printColors, is(message.recipient.printDetails.printColors));
 
-		Message copyOfMessageWithoutPrintDetails = Message.copyMessageWithOnlyDigipostDetails(message);
+		assertThat("When copying to only print, the file type should be set to pdf",
+				copyOfMessageWithPrintDetailsOnly.primaryDocument.digipostFileType, is(PDF.toString()));
+		for(Document doc : copyOfMessageWithPrintDetailsOnly.getAllDocuments()){
+			assertThat("When copying to only print, the file type should be set to pdf", doc.digipostFileType, is(PDF.toString()));
+		}
 
-		assertThat(copyOfMessageWithoutPrintDetails.deliveryTime, is(message.deliveryTime));
-		assertThat(copyOfMessageWithoutPrintDetails.invoiceReference, is(message.invoiceReference));
-		assertThat(copyOfMessageWithoutPrintDetails.messageId, is(message.messageId));
-		assertThat(copyOfMessageWithoutPrintDetails.senderId, is(message.senderId));
-		assertThat(copyOfMessageWithoutPrintDetails.recipient.digipostAddress, is(message.recipient.digipostAddress));
-		assertThat(copyOfMessageWithoutPrintDetails.recipient.organisationNumber, is(message.recipient.organisationNumber));
-		assertThat(copyOfMessageWithoutPrintDetails.recipient.personalIdentificationNumber, is(message.recipient.personalIdentificationNumber));
-		assertNull(copyOfMessageWithoutPrintDetails.recipient.printDetails);
+		assertThat(copyOfMessageWithPrintDetailsOnly.recipient.printDetails.recipient.name, is(message.recipient.printDetails.recipient.name));
+		assertThat(copyOfMessageWithPrintDetailsOnly.recipient.printDetails.recipient.norwegianAddress.addressline1, is(message.recipient.printDetails.recipient.norwegianAddress.addressline1));
+
+		Message copyOfMessageWithDigipostDetailsOnly = Message.copyMessageWithOnlyDigipostDetails(message);
+
+		assertThat(copyOfMessageWithDigipostDetailsOnly.deliveryTime, is(message.deliveryTime));
+		assertThat(copyOfMessageWithDigipostDetailsOnly.invoiceReference, is(message.invoiceReference));
+		assertThat(copyOfMessageWithDigipostDetailsOnly.messageId, is(message.messageId));
+		assertThat(copyOfMessageWithDigipostDetailsOnly.senderId, is(message.senderId));
+		assertThat(copyOfMessageWithDigipostDetailsOnly.recipient.digipostAddress, is(message.recipient.digipostAddress));
+		assertThat(copyOfMessageWithDigipostDetailsOnly.recipient.organisationNumber, is(message.recipient.organisationNumber));
+		assertThat(copyOfMessageWithDigipostDetailsOnly.recipient.personalIdentificationNumber, is(message.recipient.personalIdentificationNumber));
+		assertNull(copyOfMessageWithDigipostDetailsOnly.recipient.printDetails);
+
+		assertThat(copyOfMessageWithDigipostDetailsOnly.primaryDocument.digipostFileType, is(HTML.toString()));
+		for(Document doc : copyOfMessageWithDigipostDetailsOnly.getAllDocuments()){
+			assertThat(doc.digipostFileType, is(HTML.toString()));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Denna branchen tillåter atomic att skicka olika content (InputStreams) nær man anvænder fallback till print. Ett exempel ær att skicka html till digipost brukare och pdf som printas om en brukare inte finnes i systemet. 