### PR TITLE
EHF-support och multipla tekniska typer tillåtna

### DIFF
--- a/src/main/java/no/digipost/api/client/representations/Document.java
+++ b/src/main/java/no/digipost/api/client/representations/Document.java
@@ -18,13 +18,11 @@ package no.digipost.api.client.representations;
 
 import no.motif.f.Fn;
 import no.motif.f.Predicate;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.xml.bind.annotation.*;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import static no.motif.Singular.optional;
@@ -49,6 +47,7 @@ import static org.apache.commons.lang3.StringUtils.*;
 })
 @XmlSeeAlso({ Invoice.class })
 public class Document extends Representation {
+
 	private final static Pattern UUID_PATTERN = Pattern.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
 
 
@@ -105,7 +104,7 @@ public class Document extends Representation {
 	public Document(String uuid, String subject, FileType fileType, String openingReceipt,
 					SmsNotification smsNotification, EmailNotification emailNotification,
 					AuthenticationLevel authenticationLevel,
-					SensitivityLevel sensitivityLevel, Boolean opened, String technicalType) {
+					SensitivityLevel sensitivityLevel, Boolean opened, String... technicalType) {
 		this.uuid = lowerCase(uuid);
 		this.subject = subject;
 		this.digipostFileType = Objects.toString(fileType, null);
@@ -115,8 +114,24 @@ public class Document extends Representation {
 		this.emailNotification = emailNotification;
 		this.authenticationLevel = authenticationLevel;
 		this.sensitivityLevel = sensitivityLevel;
-		this.technicalType = technicalType;
+		this.technicalType = parseTechnicalTypes(technicalType);
 		validate();
+	}
+
+	static String parseTechnicalTypes(String... technicalTypes){
+		if(technicalTypes == null || technicalTypes.length == 0){
+			return null;
+		}
+
+		Set<String> cleanedStrings = new HashSet<>();
+		for(String st : technicalTypes){
+			if(st != null && !st.isEmpty()){
+				cleanedStrings.add(st.trim());
+			}
+		}
+
+		return cleanedStrings.size() != 0 ? StringUtils.join(cleanedStrings, ",") : null;
+
 	}
 
 	public static Document copyDocumentAndSetDigipostFileTypeToPdf(Document doc){
@@ -149,9 +164,9 @@ public class Document extends Representation {
 		}
     }
 
-	public static Document technicalAttachment(String type, FileType fileType) {
+	public static Document technicalAttachment(FileType fileType, String... type) {
 		Document document = new Document(UUID.randomUUID().toString(), null, fileType);
-		document.technicalType = type;
+		document.technicalType = parseTechnicalTypes(type);
 		return document;
 	}
 
@@ -208,8 +223,8 @@ public class Document extends Representation {
     	return new FileType(doc.digipostFileType);
     }};
 
-	public String getTechnicalType() {
-		return technicalType;
+	public String[] getTechnicalType() {
+		return technicalType != null ? technicalType.split(",") : null;
 	}
 
 	public boolean isOpened() {

--- a/src/main/java/no/digipost/api/client/representations/FileType.java
+++ b/src/main/java/no/digipost/api/client/representations/FileType.java
@@ -36,6 +36,7 @@ public final class FileType {
 	public static final FileType JPEG = new FileType("jpeg");
 	public static final FileType GIF = new FileType("gif");
 	public static final FileType ZIP = new FileType("zip");
+	public static final FileType EHF = new FileType("ehf");
 
 	private final String fileType;
 

--- a/src/main/java/no/digipost/api/client/representations/Invoice.java
+++ b/src/main/java/no/digipost/api/client/representations/Invoice.java
@@ -57,10 +57,23 @@ public class Invoice
 		this(uuid, subject, fileType, null, null, null, null, null, kid, amount, account, dueDate);
 	}
 
+	public Invoice(String uuid, String subject, FileType fileType, String kid, BigDecimal amount, String account, LocalDate dueDate,
+				   Boolean opened, String technicalType, AuthenticationLevel authenticationLevel) {
+		this(uuid, subject, fileType, null, null, null, authenticationLevel, null, kid, amount, account, dueDate, opened, technicalType);
+	}
+
 	public Invoice(String uuid, String subject, FileType fileType, String openingReceipt, SmsNotification smsNotification,
 	               EmailNotification emailNotification, AuthenticationLevel authenticationLevel, SensitivityLevel sensitivityLevel,
 				   String kid, BigDecimal amount, String account, LocalDate dueDate) {
-		super(uuid, subject, fileType, openingReceipt, smsNotification, emailNotification, authenticationLevel, sensitivityLevel);
+		this(uuid, subject, fileType, openingReceipt, smsNotification, emailNotification, authenticationLevel, sensitivityLevel,
+				kid, amount, account, dueDate, null, null);
+	}
+
+	public Invoice(String uuid, String subject, FileType fileType, String openingReceipt, SmsNotification smsNotification,
+				   EmailNotification emailNotification, AuthenticationLevel authenticationLevel, SensitivityLevel sensitivityLevel,
+				   String kid, BigDecimal amount, String account, LocalDate dueDate, Boolean opened, String... technicalType) {
+		super(uuid, subject, fileType, openingReceipt, smsNotification, emailNotification, authenticationLevel, sensitivityLevel,
+				opened, technicalType);
 		this.kid = kid;
 		this.amount = amount;
 		this.account = account;

--- a/src/test/java/no/digipost/api/client/representations/DocumentTest.java
+++ b/src/test/java/no/digipost/api/client/representations/DocumentTest.java
@@ -15,22 +15,39 @@
  */
 package no.digipost.api.client.representations;
 
+import junit.framework.Assert;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
+import javax.print.Doc;
 import javax.xml.parsers.DocumentBuilder;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.UUID;
 
+import static junit.framework.Assert.assertNull;
+import static junit.framework.TestCase.assertTrue;
 import static no.digipost.api.client.representations.FileType.HTML;
 import static no.digipost.api.client.representations.FileType.PDF;
 import static no.digipost.api.client.representations.Message.MessageBuilder.newMessage;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 public class DocumentTest {
+
+	@Test
+	public void correctlyReadsTechnicalTypes(){
+		String s = Document.parseTechnicalTypes(new String[]{"TekniskType1", "TekniskType2", "", "", "TekniskType3", null, null, "TekniskType4"});
+		assertThat(s.length(), is("TekniskType1".length()*4 + 3));
+		assertTrue(s.contains("TekniskType1"));
+		assertTrue(s.contains("TekniskType2"));
+		assertTrue(s.contains("TekniskType3"));
+		assertTrue(s.contains("TekniskType4"));
+
+		assertThat(Document.parseTechnicalTypes(null), nullValue());
+	}
 
 	@Test
 	public void assertThatDocumentClassHaveNotBeenChangedWithoutChangingDocumentCopyMethod() {

--- a/src/test/java/no/digipost/api/client/representations/MessageTest.java
+++ b/src/test/java/no/digipost/api/client/representations/MessageTest.java
@@ -182,7 +182,7 @@ public class MessageTest {
 	public void sortsDocumentsByTheSameOrderAsTheyAppearInTheMessage() {
 		Document hoved = new Document(UUID.randomUUID().toString(), "hoved", GIF);
 		Document a1 = new Document(UUID.randomUUID().toString(), "a1", PDF);
-		Document a2 = technicalAttachment("uhu, så teknisk!", ZIP);
+		Document a2 = technicalAttachment(ZIP, "uhu, så teknisk!");
 		Document a3 = new Document(UUID.randomUUID().toString(), "a3", HTML);
 		Message message = newMessage("id", hoved).attachments(asList(a1, a2, a3)).digipostAddress(new DigipostAddress("blah#ABCD")).build();
 
@@ -193,7 +193,7 @@ public class MessageTest {
 	public void sortingDocumentsNotInMessageByOrderInMessageThrowsException() {
 		Document hoved = new Document(UUID.randomUUID().toString(), "hoved", GIF);
 		Document a1 = new Document(UUID.randomUUID().toString(), "a1", PDF);
-		Document a2 = technicalAttachment("uhu, så teknisk!", ZIP);
+		Document a2 = technicalAttachment(ZIP, "uhu, så teknisk!");
 		Document notInMessage = new Document(UUID.randomUUID().toString(), "a3", HTML);
 		Message message = newMessage("id", hoved).attachments(asList(a1, a2)).digipostAddress(new DigipostAddress("blah#ABCD")).build();
 

--- a/src/test/java/no/digipost/api/client/representations/XsdValidationTest.java
+++ b/src/test/java/no/digipost/api/client/representations/XsdValidationTest.java
@@ -93,7 +93,7 @@ public class XsdValidationTest {
 		Message messageWithTechnicalAttachment = newMessage(UUID.randomUUID().toString(),
 					new Document(UUID.randomUUID().toString(), "subject", PDF, null, new SmsNotification(), null, TWO_FACTOR, NORMAL))
 				.personalIdentificationNumber(new PersonalIdentificationNumber("12345678901"))
-				.attachments(Collections.singleton(Document.technicalAttachment("tech-type", PDF)))
+				.attachments(Collections.singleton(Document.technicalAttachment(PDF, "tech-type")))
 				.build();
 
 


### PR DESCRIPTION
För att tillåta support av EHF fakturor i MF-adapter så krävs det att Document kan ha flera tekniska vedlegg.

Jag vill ha en ny filtyp för att vara lite ryddig och skilja ut själva original EHF som ska gå in och sparas i digipost.

Eftersom Offentliga nu ska kunna skicka fakturor (Har inte varit möjligt innan såvitt jag vet), så krävs det också att FLYTTET_POST också kan komma vara fakturor. Därför måste jag kunna skapa en faktura som varit opened innan och har därför ändrat konstruktorn.

