### PR TITLE
Improved GetAgreements and error handling

### DIFF
--- a/src/main/java/no/digipost/api/client/userdocuments/ApiService.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/ApiService.java
@@ -54,17 +54,11 @@ public class ApiService {
 	private final URI serviceEndpoint;
 	private final BrokerId brokerId;
 	private final CloseableHttpClient httpClient;
-	private final RequestConfig config;
 
-	public ApiService(final URI serviceEndpoint, final BrokerId brokerId, final CloseableHttpClient httpClient, final HttpHost proxy) {
+	public ApiService(final URI serviceEndpoint, final BrokerId brokerId, final CloseableHttpClient httpClient) {
 		this.serviceEndpoint = serviceEndpoint;
 		this.brokerId = brokerId;
 		this.httpClient = httpClient;
-		if (proxy != null) {
-			this.config = RequestConfig.custom().setProxy(proxy).build();
-		} else {
-			this.config = null;
-		}
 	}
 
 	public CloseableHttpResponse identifyUser(final SenderId senderId, final UserId userId, final String requestTrackingId) {
@@ -192,9 +186,6 @@ public class ApiService {
 
 	private CloseableHttpResponse send(HttpRequestBase request) {
 		try {
-			if (config != null) {
-				request.setConfig(config);
-			}
 			request.setHeader(X_Digipost_UserId, brokerId.getIdAsString());
 			return httpClient.execute(request);
 		} catch (ClientProtocolException e) {

--- a/src/main/java/no/digipost/api/client/userdocuments/ApiService.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/ApiService.java
@@ -15,18 +15,19 @@
  */
 package no.digipost.api.client.userdocuments;
 
-import no.digipost.api.client.errorhandling.DigipostClientException;
-import no.digipost.api.client.errorhandling.ErrorCode;
 import no.digipost.api.client.representations.EntryPoint;
 import no.digipost.api.client.representations.ErrorMessage;
 import no.digipost.cache.inmemory.SingleCached;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
-import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.*;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -61,18 +62,18 @@ public class ApiService {
 		this.httpClient = httpClient;
 	}
 
-	public CloseableHttpResponse identifyUser(final SenderId senderId, final UserId userId, final String requestTrackingId) {
+	public IdentificationResult identifyUser(final SenderId senderId, final UserId userId, final String requestTrackingId, final ResponseHandler<IdentificationResult> handler) {
 		HttpPost httpPost = prepareHttpPost(getEntryPoint().getIdentificationUri().getPath());
 		httpPost.setEntity(marshallJaxbEntity(new Identification(userId)));
 		addRequestTrackingHeader(httpPost, requestTrackingId);
-		return send(httpPost);
+		return executeHttpRequest(httpPost, handler);
 	}
 
-	public CloseableHttpResponse createAgreement(final SenderId senderId, final Agreement agreement, final String requestTrackingId) {
+	public URI createAgreement(final SenderId senderId, final Agreement agreement, final String requestTrackingId, final ResponseHandler<URI> handler) {
 		HttpPost httpPost = prepareHttpPost(userAgreementsPath(senderId));
 		httpPost.setEntity(marshallJaxbEntity(agreement));
 		addRequestTrackingHeader(httpPost, requestTrackingId);
-		return send(httpPost);
+		return executeHttpRequest(httpPost, handler);
 	}
 
 	private String userAgreementsPath(final SenderId senderId) {
@@ -87,68 +88,75 @@ public class ApiService {
 		return ROOT + senderId.getId() + path;
 	}
 
-	public CloseableHttpResponse getAgreement(final URI agreementURI, final String requestTrackingId) {
+	public Agreement getAgreement(final URI agreementURI, final String requestTrackingId, final ResponseHandler<Agreement> handler) {
 		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint)
 				.setPath(agreementURI.getPath());
-		return doGetRequest(requestTrackingId, uriBuilder);
+		HttpGet httpGet = new HttpGet(buildUri(uriBuilder));
+		httpGet.setHeader(HttpHeaders.ACCEPT, DIGIPOST_MEDIA_TYPE_USERS_V1);
+		addRequestTrackingHeader(httpGet, requestTrackingId);
+		return executeHttpRequest(httpGet, handler);
 	}
 
-	public CloseableHttpResponse getAgreement(final SenderId senderId, final AgreementType agreementType, final UserId userId, final String requestTrackingId) {
+	public GetAgreementResult getAgreement(final SenderId senderId, final AgreementType agreementType, final UserId userId, final String requestTrackingId, final ResponseHandler<GetAgreementResult> handler) {
 		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint)
 				.setPath(userAgreementsPath(senderId))
 				.setParameter("user-id", userId.getPersonalIdentificationNumber())
 				.setParameter("agreement-type", agreementType.getType());
-		return doGetRequest(requestTrackingId, uriBuilder);
+		HttpGet httpGet = new HttpGet(buildUri(uriBuilder));
+		httpGet.setHeader(HttpHeaders.ACCEPT, DIGIPOST_MEDIA_TYPE_USERS_V1);
+		addRequestTrackingHeader(httpGet, requestTrackingId);
+		return executeHttpRequest(httpGet, handler);
 	}
 
-	public CloseableHttpResponse getAgreements(final SenderId senderId, final UserId userId, final String requestTrackingId) {
+	public Agreements getAgreements(final SenderId senderId, final UserId userId, final String requestTrackingId, final ResponseHandler<Agreements> handler) {
 		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint)
 				.setPath(userAgreementsPath(senderId))
 				.setParameter("user-id", userId.getPersonalIdentificationNumber());
-		return doGetRequest(requestTrackingId, uriBuilder);
+		HttpGet httpGet = new HttpGet(buildUri(uriBuilder));
+		httpGet.setHeader(HttpHeaders.ACCEPT, DIGIPOST_MEDIA_TYPE_USERS_V1);
+		addRequestTrackingHeader(httpGet, requestTrackingId);
+		return executeHttpRequest(httpGet, handler);
 	}
 
-	public CloseableHttpResponse deleteAgrement(final URI agreementPath, final String requestTrackingId) {
-		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint)
-				.setPath(agreementPath.getPath());
+	public void deleteAgrement(final URI agreementPath, final String requestTrackingId, final ResponseHandler<Void> handler) {
+		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint).setPath(agreementPath.getPath());
 		HttpDelete httpDelete = new HttpDelete(buildUri(uriBuilder));
 		addRequestTrackingHeader(httpDelete, requestTrackingId);
-		return send(httpDelete);
+		executeHttpRequest(httpDelete, handler);
 	}
 
-	public CloseableHttpResponse deleteAgrement(final SenderId senderId, final AgreementType agreementType, final UserId userId, final String requestTrackingId) {
+	public void deleteAgrement(final SenderId senderId, final AgreementType agreementType, final UserId userId, final String requestTrackingId, final ResponseHandler<Void> handler) {
 		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint)
 				.setPath(userAgreementsPath(senderId))
 				.setParameter("user-id", userId.getPersonalIdentificationNumber())
 				.setParameter("agreement-type", agreementType.getType());
 		HttpDelete httpDelete = new HttpDelete(buildUri(uriBuilder));
 		addRequestTrackingHeader(httpDelete, requestTrackingId);
-		return send(httpDelete);
+		executeHttpRequest(httpDelete, handler);
 	}
 
-	public CloseableHttpResponse getDocuments(final SenderId senderId, final AgreementType agreementType, final UserId userId, final String requestTrackingId) {
+	public Documents getDocuments(final SenderId senderId, final AgreementType agreementType, final UserId userId, final String requestTrackingId, final ResponseHandler<Documents> handler) {
 		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint)
 				.setPath(userDocumentsPath(senderId))
 				.setParameter(UserId.QUERY_PARAM_NAME, userId.getPersonalIdentificationNumber())
 				.setParameter(AgreementType.QUERY_PARAM_NAME, agreementType.getType());
-		return doGetRequest(requestTrackingId, uriBuilder);
-	}
-
-	public CloseableHttpResponse getDocument(final SenderId senderId, final long documentId, final String requestTrackingId) {
-		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint)
-				.setPath(userDocumentsPath(senderId) + "/" + documentId)
-				.setParameter(AgreementType.QUERY_PARAM_NAME, AgreementType.INVOICE_BANK.getType());
-		return doGetRequest(requestTrackingId, uriBuilder);
-	}
-
-	private CloseableHttpResponse doGetRequest(final String requestTrackingId, final URIBuilder uriBuilder) {
 		HttpGet httpGet = new HttpGet(buildUri(uriBuilder));
 		httpGet.setHeader(HttpHeaders.ACCEPT, DIGIPOST_MEDIA_TYPE_USERS_V1);
 		addRequestTrackingHeader(httpGet, requestTrackingId);
-		return send(httpGet);
+		return executeHttpRequest(httpGet, handler);
 	}
 
-	public CloseableHttpResponse updateInvoice(final SenderId senderId, final long documentId, final Invoice invoice, final String requestTrackingId) {
+	public Document getDocument(final SenderId senderId, final long documentId, final String requestTrackingId, final ResponseHandler<Document> handler) {
+		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint)
+				.setPath(userDocumentsPath(senderId) + "/" + documentId)
+				.setParameter(AgreementType.QUERY_PARAM_NAME, AgreementType.INVOICE_BANK.getType());
+		HttpGet httpGet = new HttpGet(buildUri(uriBuilder));
+		httpGet.setHeader(HttpHeaders.ACCEPT, DIGIPOST_MEDIA_TYPE_USERS_V1);
+		addRequestTrackingHeader(httpGet, requestTrackingId);
+		return executeHttpRequest(httpGet, handler);
+	}
+
+	public Document updateInvoice(final SenderId senderId, final long documentId, final Invoice invoice, final String requestTrackingId, final ResponseHandler<Document> handler) {
 		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint)
 				.setPath(userDocumentsPath(senderId) + "/" + documentId + "/invoice");
 		HttpPost httpPost = new HttpPost(buildUri(uriBuilder));
@@ -156,7 +164,16 @@ public class ApiService {
 		httpPost.setHeader(HttpHeaders.CONTENT_TYPE, DIGIPOST_MEDIA_TYPE_USERS_V1);
 		addRequestTrackingHeader(httpPost, requestTrackingId);
 		httpPost.setEntity(marshallJaxbEntity(invoice));
-		return send(httpPost);
+		return executeHttpRequest(httpPost, handler);
+	}
+
+	private <T> T executeHttpRequest(final HttpRequestBase request, final ResponseHandler<T> handler) {
+		try {
+			request.setHeader(X_Digipost_UserId, brokerId.getIdAsString());
+			return httpClient.execute(request, handler);
+		} catch (IOException e) {
+			throw new RuntimeIOException(e);
+		}
 	}
 
 	private URI buildUri(URIBuilder builder) {
@@ -181,17 +198,14 @@ public class ApiService {
 	}
 
 	EntryPoint getEntryPoint() {
-		return cachedEntryPoint.get();
-	}
-
-	private CloseableHttpResponse send(HttpRequestBase request) {
 		try {
-			request.setHeader(X_Digipost_UserId, brokerId.getIdAsString());
-			return httpClient.execute(request);
-		} catch (ClientProtocolException e) {
-			throw new DigipostClientException(ErrorCode.PROBLEM_WITH_REQUEST, e);
-		} catch (IOException e) {
-			throw new DigipostClientException(ErrorCode.CONNECTION_ERROR, e);
+			return cachedEntryPoint.get();
+		} catch (RuntimeException e) {
+			if (e.getCause() instanceof UserDocumentsApiException) {
+				throw (UserDocumentsApiException) e.getCause();
+			} else {
+				throw e;
+			}
 		}
 	}
 
@@ -202,23 +216,27 @@ public class ApiService {
 		return request;
 	}
 
-	private final Callable<EntryPoint> entryPoint = new Callable<EntryPoint>() {
-		@Override
-		public EntryPoint call() throws Exception {
-
-			HttpGet httpGet = new HttpGet(serviceEndpoint.resolve(ROOT));
-			httpGet.setHeader(HttpHeaders.ACCEPT, DIGIPOST_MEDIA_TYPE_V6);
-
-			try(CloseableHttpResponse execute = send(httpGet)) {
-				if (execute.getStatusLine().getStatusCode() == SC_OK) {
-					EntryPoint entryPoint = JAXB.unmarshal(execute.getEntity().getContent(), EntryPoint.class);
+	private EntryPoint performGetEntryPoint() {
+		HttpGet httpGet = new HttpGet(serviceEndpoint.resolve(ROOT));
+		httpGet.setHeader(HttpHeaders.ACCEPT, DIGIPOST_MEDIA_TYPE_V6);
+		return executeHttpRequest(httpGet, new ResponseHandler<EntryPoint>() {
+			@Override
+			public EntryPoint handleResponse(final HttpResponse response) throws ClientProtocolException, IOException {
+				if (response.getStatusLine().getStatusCode() == SC_OK) {
+					EntryPoint entryPoint = JAXB.unmarshal(response.getEntity().getContent(), EntryPoint.class);
 					return entryPoint;
 				} else {
-					ErrorMessage errorMessage = JAXB.unmarshal(execute.getEntity().getContent(), ErrorMessage.class);
-					throw new DigipostClientException(errorMessage);
+					ErrorMessage errorMessage = JAXB.unmarshal(response.getEntity().getContent(), ErrorMessage.class);
+					throw new UnexpectedResponseException(response.getStatusLine(), Error.fromErrorMessage(errorMessage));
 				}
 			}
+		});
+	}
 
+	private final Callable<EntryPoint> entryPoint = new Callable<EntryPoint>() {
+		@Override
+		public EntryPoint call() {
+			return performGetEntryPoint();
 		}
 	};
 

--- a/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
@@ -92,12 +92,18 @@ public class DigipostUserDocumentClient {
 					return new GetAgreementResult(unmarshall(response.getEntity().getContent(), Agreement.class));
 				} else if (status.getStatusCode() == HttpStatus.SC_NOT_FOUND){
 					final Error error = readErrorFromResponse(response);
+					final Supplier<UnexpectedResponseException> agreementMissingExceptionSupplier = new Supplier<UnexpectedResponseException>() {
+						@Override
+						public UnexpectedResponseException get() {
+							return new UnexpectedResponseException(status, error);
+						}
+					};
 					if (error.is(Error.UNKNOWN_USER_ID)) {
-						return new GetAgreementResult(GetAgreementResult.FailedReason.UNKNOWN_USER);
+						return new GetAgreementResult(GetAgreementResult.FailedReason.UNKNOWN_USER, agreementMissingExceptionSupplier);
 					} else if (error.is(Error.AGREEMENT_NOT_FOUND)) {
-						return new GetAgreementResult(GetAgreementResult.FailedReason.NO_AGREEMENT);
+						return new GetAgreementResult(GetAgreementResult.FailedReason.NO_AGREEMENT, agreementMissingExceptionSupplier);
 					} else if (error.is(Error.AGREEMENT_DELETED)) {
-						return new GetAgreementResult(GetAgreementResult.FailedReason.AGREEMENT_DELETED);
+						return new GetAgreementResult(GetAgreementResult.FailedReason.AGREEMENT_DELETED, agreementMissingExceptionSupplier);
 					} else {
 						throw new UnexpectedResponseException(status, error);
 					}

--- a/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
@@ -279,7 +279,11 @@ public class DigipostUserDocumentClient {
 			httpClientBuilder.addInterceptorLast(new ResponseContentSHA256Interceptor());
 			httpClientBuilder.addInterceptorLast(responseSignatureInterceptor);
 
-			final ApiService apiService = new ApiService(serviceEndpoint, brokerId, httpClientBuilder.build(), proxyHost);
+			if (proxyHost != null) {
+				httpClientBuilder.setProxy(proxyHost);
+			}
+
+			final ApiService apiService = new ApiService(serviceEndpoint, brokerId, httpClientBuilder.build());
 			apiServiceProvider.setApiService(apiService);
 			return new DigipostUserDocumentClient(apiService);
 		}

--- a/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
@@ -25,22 +25,26 @@ import no.digipost.api.client.filters.request.RequestUserAgentInterceptor;
 import no.digipost.api.client.filters.response.ResponseContentSHA256Interceptor;
 import no.digipost.api.client.filters.response.ResponseDateInterceptor;
 import no.digipost.api.client.filters.response.ResponseSignatureInterceptor;
+import no.digipost.api.client.representations.ErrorMessage;
 import no.digipost.api.client.security.CryptoUtil;
 import no.digipost.api.client.security.Pkcs12KeySigner;
 import no.digipost.api.client.util.Supplier;
 import no.digipost.http.client.DigipostHttpClientFactory;
 import no.digipost.http.client.DigipostHttpClientSettings;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpHost;
+import org.apache.http.*;
+import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLContextBuilder;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
+import javax.xml.bind.DataBindingException;
 import javax.xml.bind.JAXB;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -64,43 +68,44 @@ public class DigipostUserDocumentClient {
 		return identifyUser(senderId, userId, null); }
 
 	public IdentificationResult identifyUser(final SenderId senderId, final UserId userId, final String requestTrackingId) {
-		return handle(new Callable<CloseableHttpResponse>() {
-			@Override
-			public CloseableHttpResponse call() throws Exception {
-				return apiService.identifyUser(senderId, userId, requestTrackingId);
-			}
-		}, IdentificationResult.class);
+		return apiService.identifyUser(senderId, userId, requestTrackingId, simpleJAXBEntityHandler(IdentificationResult.class));
 	}
 
 	public URI createOrReplaceAgreement(final SenderId senderId, final Agreement agreement) {
 		return createOrReplaceAgreement(senderId, agreement, null); }
 
 	public URI createOrReplaceAgreement(final SenderId senderId, final Agreement agreement, final String requestTrackingId) {
-		final CloseableHttpResponse response = apiService.createAgreement(senderId, agreement, requestTrackingId);
-		ApiCommons.checkResponse(response);
-		try {
-			return new URI(response.getFirstHeader(HttpHeaders.LOCATION).getValue());
-		} catch (URISyntaxException e) {
-			throw new RuntimeException(e);
-		}
+		return apiService.createAgreement(senderId, agreement, requestTrackingId, createdWithLocationHandler());
 	}
 
 	public Agreement getAgreement(final URI agreementUri, final String requestTrackingId) {
-		return handle(new Callable<CloseableHttpResponse>() {
-			@Override
-			public CloseableHttpResponse call() throws Exception {
-				return apiService.getAgreement(agreementUri, requestTrackingId);
-			}
-		}, Agreement.class);
+		return apiService.getAgreement(agreementUri, requestTrackingId, simpleJAXBEntityHandler(Agreement.class));
 	}
 
-	public Agreement getAgreement(final SenderId senderId, final AgreementType type, final UserId userId, final String requestTrackingId) {
-		return handle(new Callable<CloseableHttpResponse>() {
+	public GetAgreementResult getAgreement(final SenderId senderId, final AgreementType type, final UserId userId, final String requestTrackingId) {
+		return apiService.getAgreement(senderId, type, userId, requestTrackingId, new ResponseHandler<GetAgreementResult>() {
 			@Override
-			public CloseableHttpResponse call() throws Exception {
-				return apiService.getAgreement(senderId, type, userId, requestTrackingId);
+			public GetAgreementResult handleResponse(final HttpResponse response) throws IOException {
+				final StatusLine status = response.getStatusLine();
+
+				if (status.getStatusCode() == HttpStatus.SC_OK) {
+					return new GetAgreementResult(unmarshall(response.getEntity().getContent(), Agreement.class));
+				} else if (status.getStatusCode() == HttpStatus.SC_NOT_FOUND){
+					final Error error = readErrorFromResponse(response);
+					if (error.is(Error.UNKNOWN_USER_ID)) {
+						return new GetAgreementResult(GetAgreementResult.FailedReason.UNKNOWN_USER);
+					} else if (error.is(Error.AGREEMENT_NOT_FOUND)) {
+						return new GetAgreementResult(GetAgreementResult.FailedReason.NO_AGREEMENT);
+					} else if (error.is(Error.AGREEMENT_DELETED)) {
+						return new GetAgreementResult(GetAgreementResult.FailedReason.AGREEMENT_DELETED);
+					} else {
+						throw new UnexpectedResponseException(status, error);
+					}
+				} else {
+					throw new UnexpectedResponseException(status, readErrorFromResponse(response));
+				}
 			}
-		}, Agreement.class);
+		});
 	}
 
 	public List<Agreement> getAgreements(final SenderId senderId, final UserId userId) {
@@ -108,31 +113,16 @@ public class DigipostUserDocumentClient {
 	}
 
 	public List<Agreement> getAgreements(final SenderId senderId, final UserId userId, final String requestTrackingId) {
-		final Agreements agreements = handle(new Callable<CloseableHttpResponse>() {
-			@Override
-			public CloseableHttpResponse call() throws Exception {
-				return apiService.getAgreements(senderId, userId, requestTrackingId);
-			}
-		}, Agreements.class);
+		final Agreements agreements = apiService.getAgreements(senderId, userId, requestTrackingId, simpleJAXBEntityHandler(Agreements.class));
 		return agreements.getAgreements();
 	}
 
 	public void deleteAgreement(final URI agreementPath, final String requestTrackingId) {
-		handleVoid(new Callable<CloseableHttpResponse>() {
-			@Override
-			public CloseableHttpResponse call() throws Exception {
-				return apiService.deleteAgrement(agreementPath, requestTrackingId);
-			}
-		});
+		apiService.deleteAgrement(agreementPath, requestTrackingId, voidOkHandler());
 	}
 
 	public void deleteAgreement(final SenderId senderId, final AgreementType agreementType, final UserId userId, final String requestTrackingId) {
-		handleVoid(new Callable<CloseableHttpResponse>() {
-			@Override
-			public CloseableHttpResponse call() throws Exception {
-				return apiService.deleteAgrement(senderId, agreementType, userId, requestTrackingId);
-			}
-		});
+		apiService.deleteAgrement(senderId, agreementType, userId, requestTrackingId, voidOkHandler());
 	}
 
 	public List<Document> getDocuments(final SenderId senderId, final AgreementType agreementType, final UserId userId) {
@@ -140,12 +130,7 @@ public class DigipostUserDocumentClient {
 	}
 
 	public List<Document> getDocuments(final SenderId senderId, final AgreementType agreementType, final UserId userId, final String requestTrackingId) {
-		final Documents documents = handle(new Callable<CloseableHttpResponse>() {
-			@Override
-			public CloseableHttpResponse call() throws Exception {
-				return apiService.getDocuments(senderId, agreementType, userId, requestTrackingId);
-			}
-		}, Documents.class);
+		final Documents documents = apiService.getDocuments(senderId, agreementType, userId, requestTrackingId, simpleJAXBEntityHandler(Documents.class));
 		return documents.getDocuments();
 	}
 
@@ -154,12 +139,7 @@ public class DigipostUserDocumentClient {
 	}
 
 	public Document getDocument(final SenderId senderId, final long documentId, final String requestTrackingId) {
-		return handle(new Callable<CloseableHttpResponse>() {
-			@Override
-			public CloseableHttpResponse call() throws Exception {
-				return apiService.getDocument(senderId, documentId, requestTrackingId);
-			}
-		}, Document.class);
+		return apiService.getDocument(senderId, documentId, requestTrackingId, simpleJAXBEntityHandler(Document.class));
 	}
 
 	public Document updateInvoice(final SenderId senderId, final long documentId, final Invoice invoice) {
@@ -167,12 +147,62 @@ public class DigipostUserDocumentClient {
 	}
 
 	public Document updateInvoice(final SenderId senderId, final long documentId, final Invoice invoice, final String requestTrackingId) {
-		return handle(new Callable<CloseableHttpResponse>() {
+		return apiService.updateInvoice(senderId, documentId, invoice, requestTrackingId, simpleJAXBEntityHandler(Document.class));
+	}
+
+	private ResponseHandler<Void> voidOkHandler() {
+		return new ResponseHandler<Void>() {
 			@Override
-			public CloseableHttpResponse call() throws Exception {
-				return apiService.updateInvoice(senderId, documentId, invoice, requestTrackingId);
+			public Void handleResponse(final HttpResponse response) throws IOException {
+				final StatusLine statusLine = response.getStatusLine();
+				if (isOkResponse(statusLine.getStatusCode())) {
+					return null;
+				} else {
+					throw new UnexpectedResponseException(statusLine, readErrorFromResponse(response));
+				}
 			}
-		}, Document.class);
+		};
+	}
+
+	private ResponseHandler<URI> createdWithLocationHandler() {
+		return new ResponseHandler<URI>() {
+			@Override
+			public URI handleResponse(final HttpResponse response) throws IOException {
+				final StatusLine statusLine = response.getStatusLine();
+				if (statusLine.getStatusCode() == HttpStatus.SC_CREATED) {
+					try {
+						return new URI(response.getFirstHeader(HttpHeaders.LOCATION).getValue());
+					} catch (URISyntaxException e) {
+						throw new UserDocumentsApiException("Invalid location header. Response code was " + HttpStatus.SC_CREATED, e);
+					}
+				} else {
+					throw new UnexpectedResponseException(statusLine, readErrorFromResponse(response));
+				}
+			}
+		};
+	}
+
+	private <T> ResponseHandler<T> simpleJAXBEntityHandler(final Class<T> responseType){
+		return new ResponseHandler<T>() {
+			@Override
+			public T handleResponse(final HttpResponse response) throws IOException {
+				final StatusLine statusLine = response.getStatusLine();
+				if (isOkResponse(statusLine.getStatusCode())) {
+					return JAXB.unmarshal(response.getEntity().getContent(), responseType);
+				} else {
+					throw new UnexpectedResponseException(statusLine, readErrorFromResponse(response));
+				}
+			}
+		};
+	}
+
+	public static boolean isOkResponse(final int status) {
+		return status / 100 == 2;
+	}
+
+	private static <T> T unmarshall(InputStream contentStream, Class<T> resultType) throws IOException {
+		//TODO: exception handling when reading response
+		return JAXB.unmarshal(contentStream, resultType);
 	}
 
 	private <T> T handle(final Callable<CloseableHttpResponse> action, Class<T> resultType) {
@@ -193,6 +223,25 @@ public class DigipostUserDocumentClient {
 			throw e;
 		} catch (Exception e) {
 			throw new DigipostClientException(ErrorCode.CLIENT_ERROR, e);
+		}
+	}
+
+	public static Error readErrorFromResponse(final HttpResponse response) {
+		final StatusLine statusLine = response.getStatusLine();
+		try {
+			final String body = EntityUtils.toString(response.getEntity());
+			try {
+				ErrorMessage errorMessage = unmarshall(response.getEntity().getContent(), ErrorMessage.class);
+				if (errorMessage == null) {
+					throw new UnexpectedResponseException(statusLine, body);
+				} else {
+					return Error.fromErrorMessage(errorMessage);
+				}
+			} catch (IllegalStateException | DataBindingException e) {
+				throw new UnexpectedResponseException(statusLine, body, e);
+			}
+		} catch (IOException e) {
+			throw new UnexpectedResponseException(statusLine, e);
 		}
 	}
 

--- a/src/main/java/no/digipost/api/client/userdocuments/Error.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/Error.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.userdocuments;
+
+
+import no.digipost.api.client.representations.ErrorMessage;
+
+import java.util.Objects;
+
+public class Error {
+
+	public static final Error DOCUMENT_NOT_FOUND = new Error("DOCUMENT_NOT_FOUND", "Document not found");
+	public static final Error AGREEMENT_TYPE_NOT_AVAILABLE = new Error("AGREEMENT_TYPE_NOT_AVAILABLE", "Sepcified agreement type is not available");
+	public static final Error UNKNOWN_USER_ID = new Error("UNKNOWN_USER_ID", "The user-id is not a Digipost user");
+	public static final Error NOT_AUTHORIZED = new Error("NOT_AUTHORIZED", "Not authorized");
+	public static final Error AGREEMENT_NOT_FOUND = new Error("AGREEMENT_NOT_FOUND", "Agreement not fount");
+	public static final Error AGREEMENT_DELETED = new Error("AGREEMENT_DELETED", "Agreement has bee deleted by the user");
+
+	private final String code;
+	private final String message;
+
+	private Error(final String code, final String message) {
+		this.code = code;
+		this.message = message;
+	}
+
+	public Error withCustomMessage(String message) {
+		return new Error(code, message);
+	}
+
+	public static Error fromErrorMessage(final ErrorMessage errorMessage) {
+		return new Error(errorMessage.getErrorCode(), errorMessage.getErrorMessage());
+	}
+
+	public boolean is(final Error other) {
+		return this.code.equalsIgnoreCase(other.code);
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder("Error{");
+		sb.append("code='").append(code).append('\'');
+		sb.append(", message='").append(message).append('\'');
+		sb.append('}');
+		return sb.toString();
+	}
+
+	public String getCode() {
+		return code;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		return is((Error) o);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(code);
+	}
+}

--- a/src/main/java/no/digipost/api/client/userdocuments/GetAgreementResult.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/GetAgreementResult.java
@@ -44,4 +44,12 @@ public class GetAgreementResult {
 	public FailedReason getFailedReason() {
 		return result.getError();
 	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder("GetAgreementResult{");
+		sb.append("result=").append(result);
+		sb.append('}');
+		return sb.toString();
+	}
 }

--- a/src/main/java/no/digipost/api/client/userdocuments/GetAgreementResult.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/GetAgreementResult.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.api.client.userdocuments;
 
+import no.digipost.api.client.util.Supplier;
+
 public class GetAgreementResult {
 
 	public enum FailedReason {
@@ -27,8 +29,8 @@ public class GetAgreementResult {
 		this.result = new Result.Success<>(agreement);
 	}
 
-	public GetAgreementResult(final FailedReason failedReason) {
-		this.result = new Result.Failure<>(failedReason);
+	public GetAgreementResult(final FailedReason failedReason, final Supplier<UnexpectedResponseException> agreementMissingExceptionSupplier) {
+		this.result = new Result.Failure<>(failedReason, agreementMissingExceptionSupplier);
 	}
 
 	public boolean isSuccess() {

--- a/src/main/java/no/digipost/api/client/userdocuments/GetAgreementResult.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/GetAgreementResult.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.userdocuments;
+
+public class GetAgreementResult {
+
+	public enum FailedReason {
+		UNKNOWN_USER, NO_AGREEMENT, AGREEMENT_DELETED
+	}
+
+	private final Result<Agreement, FailedReason> result;
+
+	public GetAgreementResult(final Agreement agreement) {
+		this.result = new Result.Success<>(agreement);
+	}
+
+	public GetAgreementResult(final FailedReason failedReason) {
+		this.result = new Result.Failure<>(failedReason);
+	}
+
+	public boolean isSuccess() {
+		return result.isSuccess();
+	}
+
+	public Agreement getAgreement() {
+		return result.getValue();
+	}
+
+	public FailedReason getFailedReason() {
+		return result.getError();
+	}
+}

--- a/src/main/java/no/digipost/api/client/userdocuments/Result.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/Result.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.userdocuments;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+public abstract class Result<V, E> {
+
+	private Result() {}
+
+	public abstract boolean isSuccess();
+
+	public abstract V getValue();
+
+	public abstract E getError();
+
+	static final class Success<V, E> extends Result<V, E> {
+		private final V value;
+
+		public Success(final V value) {
+			Objects.requireNonNull(value);
+			this.value = value;
+		}
+
+		@Override
+		public boolean isSuccess() {
+			return true;
+		}
+
+		@Override
+		public V getValue() {
+			return value;
+		}
+
+		@Override
+		public E getError() {
+			throw new NoSuchElementException("No error value. It is a programming error to call getError() without checking isSuccess()");
+		}
+
+		@Override
+		public boolean equals(final Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			final Success<?, ?> success = (Success<?, ?>) o;
+			return Objects.equals(value, success.value);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(value);
+		}
+
+		@Override
+		public String toString() {
+			final StringBuilder sb = new StringBuilder("Success{");
+			sb.append("value=").append(value);
+			sb.append('}');
+			return sb.toString();
+		}
+	}
+
+	static final class Failure<V, E> extends Result<V, E> {
+		private final E error;
+
+		public Failure(final E error) {
+			Objects.requireNonNull(error);
+			this.error = error;
+		}
+
+		@Override
+		public boolean isSuccess() {
+			return false;
+		}
+
+		@Override
+		public V getValue() {
+			throw new NoSuchElementException("No value. It is a programming error to call getValue() without checking isSuccess()");
+		}
+
+		@Override
+		public E getError() {
+			return error;
+		}
+
+		@Override
+		public boolean equals(final Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			final Failure<?, ?> failure = (Failure<?, ?>) o;
+			return Objects.equals(error, failure.error);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(error);
+		}
+
+		@Override
+		public String toString() {
+			final StringBuilder sb = new StringBuilder("Failure{");
+			sb.append("error=").append(error);
+			sb.append('}');
+			return sb.toString();
+		}
+	}
+}

--- a/src/main/java/no/digipost/api/client/userdocuments/RuntimeIOException.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/RuntimeIOException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.userdocuments;
+
+public class RuntimeIOException extends UserDocumentsApiException {
+
+	public RuntimeIOException(final String message) {
+		super(message);
+	}
+
+	public RuntimeIOException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+	public RuntimeIOException(final Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/main/java/no/digipost/api/client/userdocuments/UnexpectedResponseException.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/UnexpectedResponseException.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.userdocuments;
+
+import org.apache.http.StatusLine;
+
+public class UnexpectedResponseException extends UserDocumentsApiException {
+	private final Error error;
+	private final String rawBody;
+
+	public UnexpectedResponseException(final StatusLine status, final Error error) {
+		super(String.format("Unexpected response: status [%s - %s], error [%s - %s]", status.getStatusCode(), status.getReasonPhrase(), error.getCode(), error.getMessage()));
+		this.error = error;
+		this.rawBody = null;
+	}
+
+	public UnexpectedResponseException(final StatusLine status, final Exception cause) {
+		this(status, null, cause);
+	}
+
+	public UnexpectedResponseException(final StatusLine status, final String body) {
+		this(status, body, null);
+	}
+
+	public UnexpectedResponseException(final StatusLine status, final String body, final Exception cause) {
+		super(String.format("Unexpected response: status [%s - %s], response body [%s - %s]", status.getStatusCode(), status.getReasonPhrase(), body), cause);
+		this.error = null;
+		this.rawBody = body;
+	}
+
+	public Error getError() {
+		return error;
+	}
+
+	public String getRawBody() {
+		return rawBody;
+	}
+}

--- a/src/main/java/no/digipost/api/client/userdocuments/UserDocumentsApiException.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/UserDocumentsApiException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.userdocuments;
+
+public class UserDocumentsApiException extends RuntimeException {
+
+	public UserDocumentsApiException(final String message) {
+		super(message);
+	}
+
+	public UserDocumentsApiException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+	public UserDocumentsApiException(final Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/test/java/no/digipost/api/client/userdocuments/Examples.java
+++ b/src/test/java/no/digipost/api/client/userdocuments/Examples.java
@@ -65,12 +65,12 @@ public class Examples {
 		client.createOrReplaceAgreement(senderId, Agreement.createInvoiceBankAgreement(userId, false), requestTrackingId);
 
 		//GetAgreement
-		final Agreement agreement = client.getAgreement(senderId, AgreementType.INVOICE_BANK, userId, requestTrackingId);
+		final GetAgreementResult agreement = client.getAgreement(senderId, AgreementType.INVOICE_BANK, userId, requestTrackingId);
 		System.out.println(agreement);
 
 		//UpdateAgreement
 		client.createOrReplaceAgreement(senderId, Agreement.createInvoiceBankAgreement(userId, true), requestTrackingId);
-		final Agreement modifiedAgreement = client.getAgreement(senderId, AgreementType.INVOICE_BANK, userId, requestTrackingId);
+		final GetAgreementResult modifiedAgreement = client.getAgreement(senderId, AgreementType.INVOICE_BANK, userId, requestTrackingId);
 		System.out.println(modifiedAgreement);
 
 		//DeleteAgreement

--- a/src/test/java/no/digipost/api/client/userdocuments/ResultTest.java
+++ b/src/test/java/no/digipost/api/client/userdocuments/ResultTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.userdocuments;
+
+import no.digipost.api.client.util.Supplier;
+import org.junit.Test;
+
+import java.util.NoSuchElementException;
+
+public class ResultTest {
+
+	@Test(expected = NoSuchElementException.class)
+	public void successShouldThrowExcetionOnGetError() {
+		new Result.Success<>("Success!").getError();
+	}
+
+	@Test(expected = NoSuchElementException.class)
+	public void failureShouldThrowExceptionOnGetValue() {
+		new Result.Failure<>("Failure").getValue();
+	}
+
+	@Test(expected = UserDocumentsApiException.class)
+	public void failureShouldThrowCustomeExceptionOnGetValue() {
+		new Result.Failure<>("Failure", new Supplier<RuntimeException>() {
+			@Override
+			public RuntimeException get() {
+				return new UserDocumentsApiException("Custome exception");
+			}
+		}).getValue();
+	}
+}


### PR DESCRIPTION
### Functional

GetAgreements now returns a [GetAgreementResult](https://github.com/digipost/digipost-api-client-java/blob/user-documents-getagreement/src/main/java/no/digipost/api/client/userdocuments/GetAgreementResult.java) that contains an Agreement upon success or a reason why the agreement was not found:

* UNKNOWN_USER - UserId (fødselsnummer) is not a Digipost user
* NO_AGREEMENT  - UserId is a Digipost user but no agreement found for that user
* AGREEMENT_DELETED - UserId is a Digipost user and the user has deleted a previous agreement

### Technical

#### Improved error handling

The following principle is now implemented: For all expected responses be that `200 Ok` or `404 Not found` the client API methods should return normally with a result containing enough information for the client handle it. For all other responses a [UnexpectedResponseException](https://github.com/digipost/digipost-api-client-java/blob/user-documents-getagreement/src/main/java/no/digipost/api/client/userdocuments/UnexpectedResponseException.java) is thrown indicating the http response code and any error message from the server.

`UnexpectedResponseException` and any other `RuntimeExceptions` thrown by the API client is subclasses of `UserDocumentsApiException`. If a low level `IOException` is thrown from the http-client the API will throw a `RuntimeIOException` wrapping the actual IOException.

#### Improved http request handling

To ensure proper release of system resources the client implements response processing using HttpClient's `ResponseHandler` interface.