### PR TITLE
User documents filter exceptions

### DIFF
--- a/src/main/java/no/digipost/api/client/DigipostClient.java
+++ b/src/main/java/no/digipost/api/client/DigipostClient.java
@@ -135,20 +135,6 @@ public class DigipostClient {
 	}
 
 	/**
-	 * Bestemmer klienten skal kaste exception ved feil under validering av serversignatur, eller
-	 * om den heller skal logge med log level warn.
-	 *
-	 * @param throwOnError true hvis den skal kaste exception, false for warn logging
-	 */
-	public DigipostClient setThrowOnResponseValidationError(final boolean throwOnError) {
-		responseDateInterceptor.setThrowOnError(throwOnError);
-		responseHashInterceptor.setThrowOnError(throwOnError);
-		responseSignatureInterceptor.setThrowOnError(throwOnError);
-		return this;
-	}
-
-
-	/**
 	 * Oppretter en forsendelse for sending gjennom Digipost. Dersom mottaker ikke er
 	 * digipostbruker og det ligger printdetaljer på forsendelsen bestiller vi
 	 * print av brevet til vanlig postgang. (Krever at avsender har fått tilgang

--- a/src/main/java/no/digipost/api/client/filters/response/ResponseContentSHA256Interceptor.java
+++ b/src/main/java/no/digipost/api/client/filters/response/ResponseContentSHA256Interceptor.java
@@ -19,6 +19,7 @@ import no.digipost.api.client.errorhandling.DigipostClientException;
 import no.digipost.api.client.util.LoggingUtil;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.*;
+import org.apache.http.cookie.CookieOrigin;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.protocol.HttpContext;
 import org.bouncycastle.crypto.digests.SHA256Digest;
@@ -45,17 +46,16 @@ public class ResponseContentSHA256Interceptor implements HttpResponseInterceptor
 
 	@Override
 	public void process(HttpResponse response, HttpContext context) throws HttpException, IOException {
+		if ("/".equals(((CookieOrigin)(context.getAttribute("http.cookie-origin"))).getPath())) {
+			return;
+		}
+
 		try {
 			validerContentHash(response);
 		} catch (Exception e) {
 			LoggingUtil.logResponse(response);
 			logOrThrow("Det skjedde en feil under signatursjekk: " + e.getMessage(), e);
 		}
-	}
-
-	private boolean hasHeader(final HttpResponse response, final String x_content_sha256) {
-		final String sha256Header = findHeader(response, X_Content_SHA256);
-		return !isBlank(sha256Header);
 	}
 
 	private void validerContentHash(final HttpResponse response) {

--- a/src/main/java/no/digipost/api/client/filters/response/ResponseContentSHA256Interceptor.java
+++ b/src/main/java/no/digipost/api/client/filters/response/ResponseContentSHA256Interceptor.java
@@ -16,16 +16,16 @@
 package no.digipost.api.client.filters.response;
 
 import no.digipost.api.client.errorhandling.DigipostClientException;
-import no.digipost.api.client.util.LoggingUtil;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.*;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.cookie.CookieOrigin;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.protocol.HttpContext;
 import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.util.encoders.Base64;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -35,30 +35,12 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class ResponseContentSHA256Interceptor implements HttpResponseInterceptor {
 
-	private static final Logger LOG = LoggerFactory.getLogger(ResponseContentSHA256Interceptor.class);
-
-	private boolean shouldThrow = true;
-
-	public void setThrowOnError(final boolean shouldThrow) {
-		this.shouldThrow = shouldThrow;
-	}
-
-
 	@Override
-	public void process(HttpResponse response, HttpContext context) throws HttpException, IOException {
+	public void process(HttpResponse response, HttpContext context) {
 		if ("/".equals(((CookieOrigin)(context.getAttribute("http.cookie-origin"))).getPath())) {
 			return;
 		}
 
-		try {
-			validerContentHash(response);
-		} catch (Exception e) {
-			LoggingUtil.logResponse(response);
-			logOrThrow("Det skjedde en feil under signatursjekk: " + e.getMessage(), e);
-		}
-	}
-
-	private void validerContentHash(final HttpResponse response) {
 		try {
 			final HttpEntity entity = response.getEntity();
 			if (entity != null) {
@@ -66,16 +48,14 @@ public class ResponseContentSHA256Interceptor implements HttpResponseInterceptor
 				if (entityBytes.length > 0) {
 					String hashHeader = findHeader(response, X_Content_SHA256);
 					if (isBlank(hashHeader)) {
-						throw new DigipostClientException(SERVER_SIGNATURE_ERROR,
-								"Mangler X-Content-SHA256-header - server-signatur kunne ikke valideres");
+						throw new DigipostClientException(SERVER_SIGNATURE_ERROR, "Mangler X-Content-SHA256-header - server-signatur kunne ikke valideres");
 					}
 					validerBytesMotHashHeader(hashHeader, entityBytes);
 				}
 				response.setEntity(new ByteArrayEntity(entityBytes));
 			}
 		} catch (IOException e) {
-			throw new DigipostClientException(SERVER_SIGNATURE_ERROR,
-					"Det skjedde en feil under uthenting av innhold for validering av X-Content-SHA256-header - server-signatur kunne ikke valideres");
+			throw new DigipostClientException(SERVER_SIGNATURE_ERROR, "Det skjedde en feil under uthenting av innhold for validering av X-Content-SHA256-header - server-signatur kunne ikke valideres", e);
 		}
 	}
 
@@ -98,22 +78,7 @@ public class ResponseContentSHA256Interceptor implements HttpResponseInterceptor
 		digest.doFinal(result, 0);
 		String ourHash = new String(Base64.encode(result));
 		if (!serverHash.equals(ourHash)) {
-			throw new DigipostClientException(SERVER_SIGNATURE_ERROR,
-					"X-Content-SHA256-header matchet ikke innholdet - server-signatur er feil.");
-		}
-	}
-
-	private void logOrThrow(final String message, final Exception e) {
-		if (shouldThrow) {
-			if (e instanceof DigipostClientException) {
-				throw (DigipostClientException) e;
-			} else {
-				throw new DigipostClientException(SERVER_SIGNATURE_ERROR, message, e);
-			}
-		} else {
-			LOG.warn("Feil under validering av server signatur: '" + e.getMessage() + "'. " +
-					(LOG.isDebugEnabled() ? "" : "Konfigurer debug-logging for " + LOG.getName() + " for å se full stacktrace."));
-			LOG.debug(e.getMessage(), e);
+			throw new DigipostClientException(SERVER_SIGNATURE_ERROR, "X-Content-SHA256-header matchet ikke innholdet - server-signatur er feil.");
 		}
 	}
 }

--- a/src/main/java/no/digipost/api/client/filters/response/ResponseSignatureInterceptor.java
+++ b/src/main/java/no/digipost/api/client/filters/response/ResponseSignatureInterceptor.java
@@ -67,7 +67,6 @@ public class ResponseSignatureInterceptor implements HttpResponseInterceptor {
 
 	@Override
 	public void process(HttpResponse response, HttpContext context) throws HttpException, IOException {
-		// TODO configure this on relevant WebTarget instead
 		if ("/".equals(((CookieOrigin)(context.getAttribute("http.cookie-origin"))).getPath())) {
 			eventLogger.log("Verifiserer ikke signatur fordi det er rotressurs vi hentet.");
 			return;

--- a/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
@@ -279,6 +279,11 @@ public class DigipostUserDocumentClient {
 			return this;
 		}
 
+        public Builder setHttpClientBuilder(final HttpClientBuilder HttpClientBuilder) {
+            this.httpClientBuilder = httpClientBuilder;
+            return this;
+        }
+
 		public Builder veryDangerouslyDisableCertificateVerificationWhichIsAbsolutelyUnfitForProductionCode() {
 			if (this.serviceEndpoint.compareTo(PRODUCTION_ENDPOINT) == 0) {
 				throw new RuntimeException("You should never ever disable certificate verification when connecting to the production endpoint");

--- a/src/test/java/no/digipost/api/client/filters/response/ResponseDateInterceptorTest.java
+++ b/src/test/java/no/digipost/api/client/filters/response/ResponseDateInterceptorTest.java
@@ -15,7 +15,6 @@
  */
 package no.digipost.api.client.filters.response;
 
-import no.digipost.api.client.MessageSenderTest;
 import no.digipost.api.client.MessageSenderTest.StatusLineMock;
 import no.digipost.api.client.errorhandling.DigipostClientException;
 import org.apache.http.HttpException;
@@ -54,7 +53,6 @@ public class ResponseDateInterceptorTest {
 	@Before
 	public void setUp() {
 		responseDateInterceptor = new ResponseDateInterceptor();
-		responseDateInterceptor.setThrowOnError(true);
 		when(httpResponseMock.getStatusLine()).thenReturn(new StatusLineMock(200));
 	}
 
@@ -65,7 +63,7 @@ public class ResponseDateInterceptorTest {
 			responseDateInterceptor.process(httpResponseMock, httpContextMock);
 			fail("Skulle ha kastet feil grunnet manglende Date-header");
 		} catch (DigipostClientException e) {
-			assertThat(e.getMessage(), containsString("Mangler Date-header"));
+			assertThat(e.getMessage(), containsString("Respons mangler Date-header"));
 		}
 	}
 
@@ -112,12 +110,4 @@ public class ResponseDateInterceptorTest {
 			assertThat(e.getMessage(), containsString("Date-header fra server er for gammel"));
 		}
 	}
-
-	@Test
-	public void skal_ikke_kaste_feil_om_vi_ikke_vil_det() throws IOException, HttpException {
-		responseDateInterceptor.setThrowOnError(false);
-		when(httpResponseMock.getAllHeaders()).thenReturn(new BasicHeader[]{});
-		responseDateInterceptor.process(httpResponseMock, httpContextMock);
-	}
-
 }

--- a/src/test/java/no/digipost/api/client/filters/response/ResponseSignatureFilterTest.java
+++ b/src/test/java/no/digipost/api/client/filters/response/ResponseSignatureFilterTest.java
@@ -60,15 +60,8 @@ public class ResponseSignatureFilterTest {
 				return apiServiceMock.getEntryPoint().getCertificate().getBytes();
 			}
 		});
-		responseSignatureInterceptor.setThrowOnError(true);
 		when(httpContextMock.getAttribute(anyString())).thenReturn(new CookieOrigin("host", 123, "/some/resource", true));
 		when(httpResponseMock.getAllHeaders()).thenReturn(new BasicHeader[]{});
-	}
-
-	@Test
-	public void skal_ikke_kaste_feil_om_vi_ikke_vil_det() throws IOException, HttpException {
-		responseSignatureInterceptor.setThrowOnError(false);
-		responseSignatureInterceptor.process(httpResponseMock, httpContextMock);
 	}
 
 	@Test


### PR DESCRIPTION
Removes complex exception handling in response filters. The filters used to catch all RuntimeExceptions and each has some logic to determine if it was to just log it, rethrow it or unwrap and rethrow. This seemed unnecessary complex.

The option to log instead of throw has been removed. There is no other way to signal an error in the filters than by throwing and exception. Therefore the option didn't make any sense.