### PR TITLE
User documents filter exceptions

### DIFF
--- a/src/main/java/no/digipost/api/client/errorhandling/DigipostClientException.java
+++ b/src/main/java/no/digipost/api/client/errorhandling/DigipostClientException.java
@@ -18,9 +18,10 @@ package no.digipost.api.client.errorhandling;
 import no.digipost.api.client.representations.ErrorMessage;
 import no.digipost.api.client.representations.Link;
 import no.digipost.api.client.representations.Relation;
+import no.digipost.api.client.util.ResponseExceptionSupplier;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.StatusLine;
 
-import javax.swing.text.html.Option;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -111,4 +112,12 @@ public class DigipostClientException extends RuntimeException {
 		return prefix + error.getErrorMessage();
 	}
 
+	public static ResponseExceptionSupplier<DigipostClientException> getExceptionSupplier(final ErrorCode errorCode) {
+		return new ResponseExceptionSupplier<DigipostClientException>() {
+			@Override
+			public DigipostClientException get(final StatusLine line, final String message) {
+				return new DigipostClientException(errorCode, message);
+			}
+		};
+	}
 }

--- a/src/main/java/no/digipost/api/client/errorhandling/ErrorCode.java
+++ b/src/main/java/no/digipost/api/client/errorhandling/ErrorCode.java
@@ -112,11 +112,7 @@ public enum ErrorCode {
 	INVALID_RETURN_ADDRESS(CLIENT_DATA),
 	INVALID_PDF_CONTENT(CLIENT_DATA),
 	INVALID_MONETARY_AMOUNT(CLIENT_DATA),
-	AUTHENTICATION_LEVEL_TOO_LOW(CLIENT_DATA),
-
-	//User documents
-	AGREEMENT_NOT_FOUND(CLIENT_DATA)
-	;
+	AUTHENTICATION_LEVEL_TOO_LOW(CLIENT_DATA);
 
 	private static final Map<String, ErrorCode> errorByName = new HashMap<>(); static {
 		for (ErrorCode errorCode : values()) {

--- a/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
@@ -102,11 +102,11 @@ public class DigipostUserDocumentClient {
 							return new UnexpectedResponseException(status, error);
 						}
 					};
-					if (error.is(Error.UNKNOWN_USER_ID)) {
+					if (error.hasCode(ErrorCode.UNKNOWN_USER_ID)) {
 						return new GetAgreementResult(GetAgreementResult.FailedReason.UNKNOWN_USER, agreementMissingExceptionSupplier);
-					} else if (error.is(Error.AGREEMENT_NOT_FOUND)) {
+					} else if (error.hasCode(ErrorCode.AGREEMENT_NOT_FOUND)) {
 						return new GetAgreementResult(GetAgreementResult.FailedReason.NO_AGREEMENT, agreementMissingExceptionSupplier);
-					} else if (error.is(Error.AGREEMENT_DELETED)) {
+					} else if (error.hasCode(ErrorCode.AGREEMENT_DELETED)) {
 						return new GetAgreementResult(GetAgreementResult.FailedReason.AGREEMENT_DELETED, agreementMissingExceptionSupplier);
 					} else {
 						throw new UnexpectedResponseException(status, error);
@@ -186,7 +186,7 @@ public class DigipostUserDocumentClient {
 					try {
 						return new URI(response.getFirstHeader(HttpHeaders.LOCATION).getValue());
 					} catch (URISyntaxException e) {
-						throw new UserDocumentsApiException("Invalid location header. Response code was " + HttpStatus.SC_CREATED, e);
+						throw new UnexpectedResponseException(statusLine, ErrorCode.GENERAL_ERROR, "Invalid location header", e);
 					}
 				} else {
 					throw new UnexpectedResponseException(statusLine, readErrorFromResponse(response));
@@ -220,15 +220,15 @@ public class DigipostUserDocumentClient {
 			try {
 				T result = JAXB.unmarshal(response.getEntity().getContent(), returnType);
 				if (result == null) {
-					throw new UnexpectedResponseException(statusLine, body);
+					throw new UnexpectedResponseException(statusLine, ErrorCode.GENERAL_ERROR, body);
 				} else {
 					return result;
 				}
 			} catch (IllegalStateException | DataBindingException e) {
-				throw new UnexpectedResponseException(statusLine, body, e);
+				throw new UnexpectedResponseException(statusLine, ErrorCode.GENERAL_ERROR, body, e);
 			}
 		} catch (IOException e) {
-			throw new UnexpectedResponseException(statusLine, e);
+			throw new UnexpectedResponseException(statusLine, ErrorCode.IO_EXCEPTION, e.getMessage(), e);
 		}
 	}
 

--- a/src/main/java/no/digipost/api/client/userdocuments/Error.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/Error.java
@@ -18,47 +18,29 @@ package no.digipost.api.client.userdocuments;
 
 import no.digipost.api.client.representations.ErrorMessage;
 
-import java.util.Objects;
-
 public class Error {
 
-	public static final Error DOCUMENT_NOT_FOUND = new Error("DOCUMENT_NOT_FOUND", "Document not found");
-	public static final Error AGREEMENT_TYPE_NOT_AVAILABLE = new Error("AGREEMENT_TYPE_NOT_AVAILABLE", "Sepcified agreement type is not available");
-	public static final Error UNKNOWN_USER_ID = new Error("UNKNOWN_USER_ID", "The user-id is not a Digipost user");
-	public static final Error NOT_AUTHORIZED = new Error("NOT_AUTHORIZED", "Not authorized");
-	public static final Error AGREEMENT_NOT_FOUND = new Error("AGREEMENT_NOT_FOUND", "Agreement not fount");
-	public static final Error AGREEMENT_DELETED = new Error("AGREEMENT_DELETED", "Agreement has bee deleted by the user");
-
-	private final String code;
+	private final ErrorCode code;
 	private final String message;
 
-	private Error(final String code, final String message) {
+	private Error(final ErrorCode code, final String message) {
 		this.code = code;
 		this.message = message;
 	}
 
-	public Error withCustomMessage(String message) {
-		return new Error(code, message);
-	}
-
 	public static Error fromErrorMessage(final ErrorMessage errorMessage) {
-		return new Error(errorMessage.getErrorCode(), errorMessage.getErrorMessage());
-	}
-
-	public boolean is(final Error other) {
-		return this.code.equalsIgnoreCase(other.code);
+		return new Error(new ErrorCode(errorMessage.getErrorCode()), errorMessage.getErrorMessage());
 	}
 
 	@Override
 	public String toString() {
-		final StringBuilder sb = new StringBuilder("Error{");
-		sb.append("code='").append(code).append('\'');
-		sb.append(", message='").append(message).append('\'');
-		sb.append('}');
-		return sb.toString();
+		return "Error{" +
+				"code=" + code +
+				", message='" + message + '\'' +
+				'}';
 	}
 
-	public String getCode() {
+	public ErrorCode getCode() {
 		return code;
 	}
 
@@ -66,15 +48,7 @@ public class Error {
 		return message;
 	}
 
-	@Override
-	public boolean equals(final Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
-		return is((Error) o);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(code);
+	public boolean hasCode(final ErrorCode errorCode) {
+		return code.isEqual(errorCode);
 	}
 }

--- a/src/main/java/no/digipost/api/client/userdocuments/ErrorCode.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/ErrorCode.java
@@ -27,6 +27,7 @@ public class ErrorCode extends JustA<String> implements IsEqual<ErrorCode> {
 	public static final ErrorCode SIGNATURE_ERROR = new ErrorCode("SIGNATURE_ERROR");
 	public static final ErrorCode GENERAL_ERROR = new ErrorCode("GENERAL_ERROR");
 	public static final ErrorCode IO_EXCEPTION = new ErrorCode("IO_EXCEPTION_ERROR");
+	public static final ErrorCode SERVER_SIGNATURE_ERROR = new ErrorCode("SERVER_SIGNATURE_ERROR");
 
 	public ErrorCode(final String errorCode) {
 		super(errorCode.toUpperCase());

--- a/src/main/java/no/digipost/api/client/userdocuments/ErrorCode.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/ErrorCode.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.userdocuments;
+
+public class ErrorCode extends JustA<String> implements IsEqual<ErrorCode> {
+
+	public static final ErrorCode DOCUMENT_NOT_FOUND = new ErrorCode("DOCUMENT_NOT_FOUND");
+	public static final ErrorCode AGREEMENT_TYPE_NOT_AVAILABLE = new ErrorCode("AGREEMENT_TYPE_NOT_AVAILABLE");
+	public static final ErrorCode UNKNOWN_USER_ID = new ErrorCode("UNKNOWN_USER_ID");
+	public static final ErrorCode NOT_AUTHORIZED = new ErrorCode("NOT_AUTHORIZED");
+	public static final ErrorCode AGREEMENT_NOT_FOUND = new ErrorCode("AGREEMENT_NOT_FOUND");
+	public static final ErrorCode AGREEMENT_DELETED = new ErrorCode("AGREEMENT_DELETED");
+	public static final ErrorCode CLIENT_TECHNICAL_ERROR = new ErrorCode("CLIENT_TECHNICAL_ERROR");
+	public static final ErrorCode SIGNATURE_ERROR = new ErrorCode("SIGNATURE_ERROR");
+	public static final ErrorCode GENERAL_ERROR = new ErrorCode("GENERAL_ERROR");
+	public static final ErrorCode IO_EXCEPTION = new ErrorCode("IO_EXCEPTION_ERROR");
+
+	public ErrorCode(final String errorCode) {
+		super(errorCode.toUpperCase());
+	}
+
+	@Override
+	public String toString() {
+		return serialize();
+	}
+
+	@Override
+	public String serialize() {
+		return value;
+	}
+
+	@Override
+	public boolean isEqual(final ErrorCode that) {
+		return this.equals(that);
+	}
+}

--- a/src/main/java/no/digipost/api/client/userdocuments/IsEqual.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/IsEqual.java
@@ -1,0 +1,5 @@
+package no.digipost.api.client.userdocuments;
+
+public interface IsEqual<T> {
+	boolean isEqual(T that);
+}

--- a/src/main/java/no/digipost/api/client/userdocuments/JustA.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/JustA.java
@@ -20,14 +20,36 @@
  */
 package no.digipost.api.client.userdocuments;
 
-public abstract class JustAValid<T> extends JustA<T> {
+import java.util.Objects;
 
-    protected JustAValid(T value, String message) {
-    	super(value);
-        if (!isValid(value)) {
-            throw new IllegalArgumentException("Invalid value " + value + " for " + getClass().getName() + " : " + message);
-        }
+public abstract class JustA<T> {
+
+    protected final T value;
+
+    protected JustA(T value) {
+        this.value = value;
     }
 
-    public abstract boolean isValid(T value);
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj instanceof JustA && getClass().isInstance(obj)) {
+            JustA<?> that = (JustA<?>) obj;
+            return Objects.equals(this.value, that.value);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return getClass() + ": '" + value.toString() + "'";
+    }
+
+    public abstract String serialize();
 }

--- a/src/main/java/no/digipost/api/client/userdocuments/RuntimeIOException.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/RuntimeIOException.java
@@ -18,14 +18,14 @@ package no.digipost.api.client.userdocuments;
 public class RuntimeIOException extends UserDocumentsApiException {
 
 	public RuntimeIOException(final String message) {
-		super(message);
+		super(ErrorCode.IO_EXCEPTION, message);
 	}
 
 	public RuntimeIOException(final String message, final Throwable cause) {
-		super(message, cause);
+		super(ErrorCode.IO_EXCEPTION, message, cause);
 	}
 
 	public RuntimeIOException(final Throwable cause) {
-		super(cause);
+		super(ErrorCode.IO_EXCEPTION, cause);
 	}
 }

--- a/src/main/java/no/digipost/api/client/userdocuments/ServerSignatureException.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/ServerSignatureException.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.userdocuments;
+
+import no.digipost.api.client.util.ResponseExceptionSupplier;
+import org.apache.http.StatusLine;
+
+public class ServerSignatureException extends UnexpectedResponseException {
+	public ServerSignatureException(final StatusLine status, final String errorMessage) {
+		this(status, errorMessage, null);
+	}
+
+	public ServerSignatureException(final StatusLine status, final String errorMessage, final Throwable cause) {
+		super(status, ErrorCode.SERVER_SIGNATURE_ERROR, errorMessage, cause);
+	}
+
+	public static ResponseExceptionSupplier<ServerSignatureException> getExceptionSupplier() {
+		return new ResponseExceptionSupplier<ServerSignatureException>() {
+			@Override
+			public ServerSignatureException get(final StatusLine status, final String message) {
+				return new ServerSignatureException(status, message);
+			}
+		};
+	}
+}

--- a/src/main/java/no/digipost/api/client/userdocuments/UnexpectedResponseException.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/UnexpectedResponseException.java
@@ -17,35 +17,23 @@ package no.digipost.api.client.userdocuments;
 
 import org.apache.http.StatusLine;
 
+import static java.lang.String.format;
+
 public class UnexpectedResponseException extends UserDocumentsApiException {
-	private final Error error;
-	private final String rawBody;
+
+	public UnexpectedResponseException(final StatusLine status, final ErrorCode errorCode, final String errorMessage) {
+		this(status, errorCode, errorMessage, null);
+	}
+
+	public UnexpectedResponseException(final StatusLine status, final ErrorCode errorCode, final String errorMessage, final Throwable cause) {
+		super(errorCode, format("Unexpected response: status [%s - %s], error [%s - %s]",
+				status.getStatusCode(),
+				status.getReasonPhrase(),
+				errorCode,
+				errorMessage), cause);
+	}
 
 	public UnexpectedResponseException(final StatusLine status, final Error error) {
-		super(String.format("Unexpected response: status [%s - %s], error [%s - %s]", status.getStatusCode(), status.getReasonPhrase(), error.getCode(), error.getMessage()));
-		this.error = error;
-		this.rawBody = null;
-	}
-
-	public UnexpectedResponseException(final StatusLine status, final Exception cause) {
-		this(status, null, cause);
-	}
-
-	public UnexpectedResponseException(final StatusLine status, final String body) {
-		this(status, body, null);
-	}
-
-	public UnexpectedResponseException(final StatusLine status, final String body, final Exception cause) {
-		super(String.format("Unexpected response: status [%s - %s], response body [%s]", status.getStatusCode(), status.getReasonPhrase(), body), cause);
-		this.error = null;
-		this.rawBody = body;
-	}
-
-	public Error getError() {
-		return error;
-	}
-
-	public String getRawBody() {
-		return rawBody;
+		this(status, error.getCode(), error.getMessage());
 	}
 }

--- a/src/main/java/no/digipost/api/client/userdocuments/UserDocumentsApiException.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/UserDocumentsApiException.java
@@ -17,15 +17,24 @@ package no.digipost.api.client.userdocuments;
 
 public class UserDocumentsApiException extends RuntimeException {
 
-	public UserDocumentsApiException(final String message) {
+	private final ErrorCode errorCode;
+
+	public UserDocumentsApiException(final ErrorCode errorCode, final String message) {
 		super(message);
+		this.errorCode = errorCode;
 	}
 
-	public UserDocumentsApiException(final String message, final Throwable cause) {
+	public UserDocumentsApiException(final ErrorCode errorCode, final String message, final Throwable cause) {
 		super(message, cause);
+		this.errorCode = errorCode;
 	}
 
-	public UserDocumentsApiException(final Throwable cause) {
+	public UserDocumentsApiException(final ErrorCode errorCode, final Throwable cause) {
 		super(cause);
+		this.errorCode = errorCode;
+	}
+
+	public ErrorCode getErrorCode() {
+		return errorCode;
 	}
 }

--- a/src/main/java/no/digipost/api/client/util/ResponseExceptionSupplier.java
+++ b/src/main/java/no/digipost/api/client/util/ResponseExceptionSupplier.java
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package no.digipost.api.client.userdocuments;
+package no.digipost.api.client.util;
 
-public interface IsEqual<T> {
-	boolean isEqual(T that);
+import org.apache.http.StatusLine;
+
+public interface ResponseExceptionSupplier<T extends RuntimeException> {
+	T get(StatusLine line, String message);
 }

--- a/src/test/java/no/digipost/api/client/filters/response/ResponseDateInterceptorTest.java
+++ b/src/test/java/no/digipost/api/client/filters/response/ResponseDateInterceptorTest.java
@@ -17,6 +17,7 @@ package no.digipost.api.client.filters.response;
 
 import no.digipost.api.client.MessageSenderTest.StatusLineMock;
 import no.digipost.api.client.errorhandling.DigipostClientException;
+import no.digipost.api.client.userdocuments.ServerSignatureException;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.message.BasicHeader;
@@ -63,6 +64,18 @@ public class ResponseDateInterceptorTest {
 			responseDateInterceptor.process(httpResponseMock, httpContextMock);
 			fail("Skulle ha kastet feil grunnet manglende Date-header");
 		} catch (DigipostClientException e) {
+			assertThat(e.getMessage(), containsString("Respons mangler Date-header"));
+		}
+	}
+
+	@Test
+	public void skal_kaste_custom_exception_når_Date_header_mangler() throws IOException, HttpException {
+		when(httpResponseMock.getAllHeaders()).thenReturn(new BasicHeader[]{});
+		try {
+			ResponseDateInterceptor responseDateInterceptor = new ResponseDateInterceptor(ServerSignatureException.getExceptionSupplier());
+			responseDateInterceptor.process(httpResponseMock, httpContextMock);
+			fail("Skulle ha kastet feil grunnet manglende Date-header");
+		} catch (ServerSignatureException e) {
 			assertThat(e.getMessage(), containsString("Respons mangler Date-header"));
 		}
 	}

--- a/src/test/java/no/digipost/api/client/userdocuments/ResultTest.java
+++ b/src/test/java/no/digipost/api/client/userdocuments/ResultTest.java
@@ -37,7 +37,7 @@ public class ResultTest {
 		new Result.Failure<>("Failure", new Supplier<RuntimeException>() {
 			@Override
 			public RuntimeException get() {
-				return new UserDocumentsApiException("Custome exception");
+				return new UserDocumentsApiException(ErrorCode.GENERAL_ERROR, "Custom exception");
 			}
 		}).getValue();
 	}


### PR DESCRIPTION
The filters that verify the response signature is shared between the send client and the user documents client. This change allows the filters to throw different exceptions depending on which client they are used from.

A new exception type `ServerSignatureException` (subclass of `UnexpectedResponseException`) will now be thrown from if something is wrong with the signature in the response from the server.