### PR TITLE
updateInvoice med InvoicePayment eller delete-operasjon

### DIFF
--- a/src/main/java/no/digipost/api/client/userdocuments/ApiService.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/ApiService.java
@@ -164,7 +164,7 @@ public class ApiService {
 		return executeHttpRequest(httpGet, handler);
 	}
 
-	public Document updateInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final InvoiceUpdate invoice, final String requestTrackingId, final ResponseHandler<Document> handler) {
+	public void updateInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final InvoiceUpdate invoice, final String requestTrackingId, final ResponseHandler<Void> handler) {
 		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint)
 				.setPath(userDocumentsPath(senderId) + "/" + documentId + "/invoice")
 				.setParameter(AgreementType.QUERY_PARAM_NAME, agreementType.getType());
@@ -173,7 +173,7 @@ public class ApiService {
 		httpPost.setHeader(HttpHeaders.CONTENT_TYPE, DIGIPOST_MEDIA_TYPE_USERS_V1);
 		addRequestTrackingHeader(httpPost, requestTrackingId);
 		httpPost.setEntity(marshallJaxbEntity(invoice));
-		return executeHttpRequest(httpPost, handler);
+		executeHttpRequest(httpPost, handler);
 	}
 
 	public DocumentCount getDocumentCount(final SenderId senderId, final AgreementType agreementType, final UserId userId, final InvoiceStatus status, final LocalDate minDueDate, final String requestTrackingId, final ResponseHandler<DocumentCount> handler) {

--- a/src/main/java/no/digipost/api/client/userdocuments/ApiService.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/ApiService.java
@@ -164,7 +164,7 @@ public class ApiService {
 		return executeHttpRequest(httpGet, handler);
 	}
 
-	public Document updateInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final InvoicePayment invoice, final String requestTrackingId, final ResponseHandler<Document> handler) {
+	public Document updateInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final InvoiceUpdate invoice, final String requestTrackingId, final ResponseHandler<Document> handler) {
 		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint)
 				.setPath(userDocumentsPath(senderId) + "/" + documentId + "/invoice")
 				.setParameter(AgreementType.QUERY_PARAM_NAME, agreementType.getType());

--- a/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
@@ -157,20 +157,20 @@ public class DigipostUserDocumentClient {
 		return apiService.getDocument(senderId, documentId, requestTrackingId, simpleJAXBEntityHandler(Document.class));
 	}
 
-	public Document payInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final InvoicePayment invoicePayment) {
-		return payInvoice(senderId, agreementType, documentId, invoicePayment, null);
+	public void payInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final InvoicePayment invoicePayment) {
+		payInvoice(senderId, agreementType, documentId, invoicePayment, null);
 	}
 
-	public Document payInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final InvoicePayment invoicePayment, final String requestTrackingId) {
-		return apiService.updateInvoice(senderId, agreementType, documentId, invoicePayment.asInvoiceUpdate(), requestTrackingId, simpleJAXBEntityHandler(Document.class));
+	public void payInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final InvoicePayment invoicePayment, final String requestTrackingId) {
+		apiService.updateInvoice(senderId, agreementType, documentId, invoicePayment.asInvoiceUpdate(), requestTrackingId, voidOkHandler());
 	}
 
-	public Document deleteInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId) {
-		return deleteInvoice(senderId, agreementType, documentId, null);
+	public void deleteInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId) {
+		deleteInvoice(senderId, agreementType, documentId, null);
 	}
 
-	public Document deleteInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final String requestTrackingId) {
-		return apiService.updateInvoice(senderId, agreementType, documentId, new InvoiceUpdate(InvoiceStatus.DELETED, null, null), requestTrackingId, simpleJAXBEntityHandler(Document.class));
+	public void deleteInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final String requestTrackingId) {
+		apiService.updateInvoice(senderId, agreementType, documentId, new InvoiceUpdate(InvoiceStatus.DELETED, null, null), requestTrackingId, voidOkHandler());
 	}
 	public long getDocumentCount(final SenderId senderId, final AgreementType agreementType, final UserId userId, final InvoiceStatus status, final LocalDate invoiceDueDateFrom) {
 		return getDocumentCount(senderId, agreementType, userId, status, invoiceDueDateFrom, null);

--- a/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/DigipostUserDocumentClient.java
@@ -157,14 +157,21 @@ public class DigipostUserDocumentClient {
 		return apiService.getDocument(senderId, documentId, requestTrackingId, simpleJAXBEntityHandler(Document.class));
 	}
 
-	public Document updateInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final InvoicePayment invoice) {
-		return updateInvoice(senderId, agreementType, documentId, invoice, null);
+	public Document payInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final InvoicePayment invoicePayment) {
+		return payInvoice(senderId, agreementType, documentId, invoicePayment, null);
 	}
 
-	public Document updateInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final InvoicePayment invoice, final String requestTrackingId) {
-		return apiService.updateInvoice(senderId, agreementType, documentId, invoice, requestTrackingId, simpleJAXBEntityHandler(Document.class));
+	public Document payInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final InvoicePayment invoicePayment, final String requestTrackingId) {
+		return apiService.updateInvoice(senderId, agreementType, documentId, invoicePayment.asInvoiceUpdate(), requestTrackingId, simpleJAXBEntityHandler(Document.class));
 	}
 
+	public Document deleteInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId) {
+		return deleteInvoice(senderId, agreementType, documentId, null);
+	}
+
+	public Document deleteInvoice(final SenderId senderId, final AgreementType agreementType, final long documentId, final String requestTrackingId) {
+		return apiService.updateInvoice(senderId, agreementType, documentId, new InvoiceUpdate(InvoiceStatus.DELETED, null, null), requestTrackingId, simpleJAXBEntityHandler(Document.class));
+	}
 	public long getDocumentCount(final SenderId senderId, final AgreementType agreementType, final UserId userId, final InvoiceStatus status, final LocalDate invoiceDueDateFrom) {
 		return getDocumentCount(senderId, agreementType, userId, status, invoiceDueDateFrom, null);
 	}

--- a/src/main/java/no/digipost/api/client/userdocuments/InvoicePayment.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/InvoicePayment.java
@@ -20,7 +20,7 @@ public class InvoicePayment {
 	private Integer paymentId;
 	private BankAccountNumber fromAccount;
 
-	public InvoicePayment(final InvoiceStatus status, final Integer paymentId, final BankAccountNumber fromAccount) {
+	public InvoicePayment(final Integer paymentId, final BankAccountNumber fromAccount) {
 		this.paymentId = paymentId;
 		this.fromAccount = fromAccount;
 	}

--- a/src/main/java/no/digipost/api/client/userdocuments/InvoiceStatus.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/InvoiceStatus.java
@@ -22,19 +22,13 @@ import javax.xml.bind.annotation.XmlType;
 @XmlEnum
 public enum InvoiceStatus {
 
-	UNPAID("unpaid"),
-	PAID("paid"),
-	DELETED("deleted");
+	UNPAID,
+	PAID,
+	DELETED;
 
 	public static final String QUERY_PARAM_NAME = "invoice-status";
 
-	private final String status;
-
-	InvoiceStatus(final String status) {
-		this.status = status;
-	}
-
 	public String getStatus() {
-		return status;
+		return name().toLowerCase();
 	}
 }

--- a/src/main/java/no/digipost/api/client/userdocuments/InvoiceUpdate.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/InvoiceUpdate.java
@@ -37,7 +37,7 @@ public class InvoiceUpdate {
 	public InvoiceUpdate(final InvoiceStatus status, final Integer paymentId, final BankAccountNumber fromAccount) {
 		this.status = status.getStatus();
 		this.paymentId = paymentId;
-		this.fromAccount = fromAccount.getAccountNumber();
+		this.fromAccount = fromAccount != null ? fromAccount.getAccountNumber() : null;
 	}
 
 	public InvoiceStatus getStatus () {

--- a/src/main/java/no/digipost/api/client/userdocuments/InvoiceUpdate.java
+++ b/src/main/java/no/digipost/api/client/userdocuments/InvoiceUpdate.java
@@ -15,14 +15,33 @@
  */
 package no.digipost.api.client.userdocuments;
 
-public class InvoicePayment {
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 
+@XmlRootElement(name = "invoice-update")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class InvoiceUpdate {
+
+	@XmlElement
+	private String status;
+	@XmlElement(name = "payment-id")
 	private Integer paymentId;
-	private BankAccountNumber fromAccount;
+	@XmlElement(name = "from-account")
+	private String fromAccount;
 
-	public InvoicePayment(final InvoiceStatus status, final Integer paymentId, final BankAccountNumber fromAccount) {
+	public InvoiceUpdate() {
+	}
+
+	public InvoiceUpdate(final InvoiceStatus status, final Integer paymentId, final BankAccountNumber fromAccount) {
+		this.status = status.getStatus();
 		this.paymentId = paymentId;
-		this.fromAccount = fromAccount;
+		this.fromAccount = fromAccount.getAccountNumber();
+	}
+
+	public InvoiceStatus getStatus () {
+		return InvoiceStatus.valueOf(status);
 	}
 
 	public int getPaymentId() {
@@ -30,10 +49,6 @@ public class InvoicePayment {
 	}
 
 	public BankAccountNumber getFromAccount() {
-		return fromAccount;
-	}
-
-	public InvoiceUpdate asInvoiceUpdate() {
-		return new InvoiceUpdate(InvoiceStatus.PAID, paymentId, fromAccount);
+		return new BankAccountNumber(fromAccount);
 	}
 }


### PR DESCRIPTION
Laget et InvoiceUpdate-objekt i tråd med apiet, og et InvoicePayment-objekt for å tvinge brukeren til å bruke gyldige typer. ApiService har en api-compliant updateInvoice-metode, mens klienten har to strengere metoder: payInvoice og deleteInvoice.