### PR TITLE
Bedre ressurshåndtering ved konsumering av entity-stream

### DIFF
--- a/src/main/java/no/digipost/api/client/filters/request/RequestSignatureInterceptor.java
+++ b/src/main/java/no/digipost/api/client/filters/request/RequestSignatureInterceptor.java
@@ -20,13 +20,13 @@ import no.digipost.api.client.Headers;
 import no.digipost.api.client.security.ClientRequestToSign;
 import no.digipost.api.client.security.RequestMessageSignatureUtil;
 import no.digipost.api.client.security.Signer;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
 import org.bouncycastle.util.encoders.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,13 +35,13 @@ import java.io.IOException;
 import java.net.URI;
 
 import static no.digipost.api.client.DigipostClient.NOOP_EVENT_LOGGER;
+import static no.motif.Singular.optional;
 
 public class RequestSignatureInterceptor implements HttpRequestInterceptor {
 
 	private static final Logger LOG = LoggerFactory.getLogger(RequestSignatureInterceptor.class);
 
 	private final Signer signer;
-	private final EventLogger eventListener;
 	private final RequestContentHashFilter hashFilter;
 	private final EventLogger eventLogger;
 
@@ -52,7 +52,6 @@ public class RequestSignatureInterceptor implements HttpRequestInterceptor {
 	public RequestSignatureInterceptor(final Signer signer, final EventLogger eventListener, final RequestContentHashFilter hashFilter){
 		eventLogger = eventListener != null ? eventListener : NOOP_EVENT_LOGGER;
 		this.signer = signer;
-		this.eventListener = eventListener;
 		this.hashFilter = hashFilter;
 	}
 
@@ -82,7 +81,7 @@ public class RequestSignatureInterceptor implements HttpRequestInterceptor {
 			if (rqEntity == null) {
 				setSignatureHeader(httpRequest);
 			} else {
-				byte[] entityBytes = IOUtils.toByteArray(rqEntity.getContent());
+				byte[] entityBytes = optional(EntityUtils.toByteArray(rqEntity)).orElse(new byte[0]);
 				hashFilter.settContentHashHeader(entityBytes, request);
 				setSignatureHeader(httpRequest);
 			}

--- a/src/main/java/no/digipost/api/client/filters/response/LoggingClientResponseInterceptor.java
+++ b/src/main/java/no/digipost/api/client/filters/response/LoggingClientResponseInterceptor.java
@@ -15,18 +15,19 @@
  */
 package no.digipost.api.client.filters.response;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static no.motif.Singular.optional;
 
 public class LoggingClientResponseInterceptor implements HttpResponseInterceptor {
 
@@ -34,10 +35,8 @@ public class LoggingClientResponseInterceptor implements HttpResponseInterceptor
 
 	@Override
 	public void process(HttpResponse response, HttpContext context) throws HttpException, IOException {
-		InputStream entityStream = response.getEntity().getContent();
-		byte[] bytes = IOUtils.toByteArray(entityStream);
-		LOG.info(new String(bytes, "UTF8"));
-		ByteArrayInputStream baos = new ByteArrayInputStream(bytes);
-		response.setEntity(new ByteArrayEntity(bytes));
+		byte[] entityBytes = optional(EntityUtils.toByteArray(response.getEntity())).orElse(new byte[0]);
+		LOG.info(new String(entityBytes, UTF_8));
+		response.setEntity(new ByteArrayEntity(entityBytes));
 	}
 }

--- a/src/main/java/no/digipost/api/client/filters/response/ResponseContentSHA256Interceptor.java
+++ b/src/main/java/no/digipost/api/client/filters/response/ResponseContentSHA256Interceptor.java
@@ -17,13 +17,13 @@ package no.digipost.api.client.filters.response;
 
 import no.digipost.api.client.errorhandling.DigipostClientException;
 import no.digipost.api.client.util.LoggingUtil;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
 import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.util.encoders.Base64;
 import org.slf4j.Logger;
@@ -70,7 +70,8 @@ public class ResponseContentSHA256Interceptor implements HttpResponseInterceptor
 				throw new DigipostClientException(SERVER_SIGNATURE_ERROR,
 						"Mangler X-Content-SHA256-header - server-signatur kunne ikke valideres");
 			}
-			byte[] entityBytes = IOUtils.toByteArray(response.getEntity().getContent());
+			byte[] entityBytes = EntityUtils.toByteArray(response.getEntity());
+			if (entityBytes == null) entityBytes = new byte[0]; //EntityUtils.toByteArray kan returnere null hvis inputstream er null
 			response.setEntity(new ByteArrayEntity(entityBytes));
 			validerBytesMotHashHeader(hashHeader, entityBytes);
 		} catch (IOException e) {

--- a/src/main/java/no/digipost/api/client/filters/response/ResponseContentSHA256Interceptor.java
+++ b/src/main/java/no/digipost/api/client/filters/response/ResponseContentSHA256Interceptor.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 
 import static no.digipost.api.client.Headers.X_Content_SHA256;
 import static no.digipost.api.client.errorhandling.ErrorCode.SERVER_SIGNATURE_ERROR;
+import static no.motif.Singular.optional;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class ResponseContentSHA256Interceptor implements HttpResponseInterceptor {
@@ -70,8 +71,7 @@ public class ResponseContentSHA256Interceptor implements HttpResponseInterceptor
 				throw new DigipostClientException(SERVER_SIGNATURE_ERROR,
 						"Mangler X-Content-SHA256-header - server-signatur kunne ikke valideres");
 			}
-			byte[] entityBytes = EntityUtils.toByteArray(response.getEntity());
-			if (entityBytes == null) entityBytes = new byte[0]; //EntityUtils.toByteArray kan returnere null hvis inputstream er null
+			byte[] entityBytes = optional(EntityUtils.toByteArray(response.getEntity())).orElse(new byte[0]);
 			response.setEntity(new ByteArrayEntity(entityBytes));
 			validerBytesMotHashHeader(hashHeader, entityBytes);
 		} catch (IOException e) {


### PR DESCRIPTION
Bruke EntityUtils.toByteArray i stedet for IOUtils for å
sikre at entity-stream closes.