### PR TITLE
Bruk riktig datoformat mot dpost-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>8.0.RC3</version>
+    <version>8.0-SNAPSHOT</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -506,7 +506,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>8.0.RC3</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>8.0-SNAPSHOT</version>
+    <version>8.0.RC3</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -506,7 +506,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>HEAD</tag>
+        <tag>8.0.RC3</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/api/client/ApiServiceImpl.java
+++ b/src/main/java/no/digipost/api/client/ApiServiceImpl.java
@@ -53,11 +53,11 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static java.util.Optional.ofNullable;
 import static no.digipost.api.client.Headers.X_Digipost_UserId;
 import static no.digipost.api.client.errorhandling.ErrorCode.PROBLEM_WITH_REQUEST;
@@ -216,10 +216,9 @@ public class ApiServiceImpl implements ApiService {
 
     @Override
     public CloseableHttpResponse getDocumentEvents(String organisation, String partId, ZonedDateTime from, ZonedDateTime to, int offset, int maxResults) {
-        DateTimeFormatter urlParamPattern = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
         URIBuilder builder = new URIBuilder(digipostUrl.resolve(getEntryPoint().getDocumentEventsUri().getPath()))
-                .setParameter("from", urlParamPattern.format(from))
-                .setParameter("to", urlParamPattern.format(to))
+                .setParameter("from", ISO_OFFSET_DATE_TIME.format(from))
+                .setParameter("to", ISO_OFFSET_DATE_TIME.format(to))
                 .setParameter("offset", String.valueOf(offset))
                 .setParameter("maxResults", String.valueOf(maxResults));
 


### PR DESCRIPTION
Etter byttet fra Joda-time til Java-time ble datoer formatert med
patternet `yyyy-MM-dd'T'HH:mm:ss.SSSZZ` litt ulike. Kolonet i offset ble
borte, slik at vi fikk

`2017-03-09T15:34:12.478+0100`

i stedet for

`2017-03-09T15:34:12.248+01:00`

Regexet som brukes i modsecurity i wafen krever det siste kolonet,
dermed fikk vi mye warnings.

Vi bruker nå i stedet `DateTimeFormatter.ISO_OFFSET_DATE_TIME`, og alt er
good.

_For spesielt interesserte_: Skal man fikse dette manuelt uten å bruke
format-konstanten fra DateTimeFormatter, kan man bruke patternet
`yyyy-MM-dd'T'HH:mm:ss.SSSXXX`.