### PR TITLE
[BUG] Missing IdentificationResult.class in JAXBContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <prerequisites>
-        <maven>3.0.3</maven>
-    </prerequisites>
-
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>digipost-open-super-pom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>8.4-SNAPSHOT</version>
+    <version>8.4.1</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -503,7 +503,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>HEAD</tag>
+        <tag>8.4.1</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>8.4.1</version>
+    <version>8.5-SNAPSHOT</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -503,7 +503,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>8.4.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/api/client/util/JAXBContextUtils.java
+++ b/src/main/java/no/digipost/api/client/util/JAXBContextUtils.java
@@ -15,17 +15,7 @@
  */
 package no.digipost.api.client.util;
 
-import no.digipost.api.client.representations.Autocomplete;
-import no.digipost.api.client.representations.DocumentEvents;
-import no.digipost.api.client.representations.DocumentStatus;
-import no.digipost.api.client.representations.EncryptionKey;
-import no.digipost.api.client.representations.EntryPoint;
-import no.digipost.api.client.representations.ErrorMessage;
-import no.digipost.api.client.representations.Identification;
-import no.digipost.api.client.representations.IdentificationResultWithEncryptionKey;
-import no.digipost.api.client.representations.Message;
-import no.digipost.api.client.representations.MessageDelivery;
-import no.digipost.api.client.representations.Recipients;
+import no.digipost.api.client.representations.*;
 import no.digipost.api.client.representations.sender.SenderInformation;
 
 import javax.xml.bind.JAXBContext;
@@ -37,7 +27,7 @@ import java.io.OutputStream;
 public class JAXBContextUtils {
     public static final JAXBContext entryPointContext = initContext(EntryPoint.class);
     public static final JAXBContext errorMessageContext = initContext(ErrorMessage.class);
-    public static final JAXBContext identificationContext = initContext(Identification.class);
+    public static final JAXBContext identificationContext = initContext(Identification.class, IdentificationResult.class);
     public static final JAXBContext messageContext = initContext(Message.class);
     public static final JAXBContext recipientsContext = initContext(Recipients.class);
     public static final JAXBContext autocompleteContext = initContext(Autocomplete.class);
@@ -48,7 +38,7 @@ public class JAXBContextUtils {
     public static final JAXBContext identificationResultWithEncryptionKeyContext = initContext(IdentificationResultWithEncryptionKey.class);
     public static final JAXBContext senderInformationContext = initContext(SenderInformation.class);
 
-    private static JAXBContext initContext(Class<?> clazz) {
+    private static JAXBContext initContext(Class<?>... clazz) {
         try {
             return JAXBContext.newInstance(clazz);
         } catch (JAXBException e) {


### PR DESCRIPTION
Missing class causes unmarshal exception for all identification calls:

```
javax.xml.bind.UnmarshalException: unexpected element (uri:"http://api.digipost.no/schema/v7", local:"identification-result").
Expected elements are <{http://api.digipost.no/schema/v7}identification>
```

FIX: Add class to correct jaxb-context