### PR TITLE
Use undertow multipart API in digipost mock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>9.0.1</version>
+    <version>9.1-SNAPSHOT</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -543,7 +543,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>9.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>9.1-SNAPSHOT</version>
+    <version>9.0.1</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -543,7 +543,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>HEAD</tag>
+        <tag>9.0.1</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/api/client/DigipostClientMock.java
+++ b/src/main/java/no/digipost/api/client/DigipostClientMock.java
@@ -48,6 +48,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static no.digipost.api.client.DigipostClientConfig.DigipostClientConfigBuilder.newBuilder;
+import static no.digipost.http.client3.DigipostHttpClientDefaults.DEFAULT_TIMEOUTS_MS;
 
 /**
  * Instansierer en DigipostClient som ikke går mot faktiskt Digipost REST-api endepunkt og
@@ -66,7 +67,7 @@ public class DigipostClientMock {
     public DigipostClientMock() {
         URI host = URI.create("http://localhost:" + PORT);
 
-        HttpClientBuilder httpClientBuilder = DigipostHttpClientFactory.createBuilder(DigipostHttpClientSettings.DEFAULT);
+        HttpClientBuilder httpClientBuilder = DigipostHttpClientFactory.createBuilder(DigipostHttpClientSettings.DEFAULT.timeouts(DEFAULT_TIMEOUTS_MS.all(0)));
 
         apiService = new ApiServiceImpl(httpClientBuilder, PORT, null, host, null);
         apiService.buildApacheHttpClientBuilder();

--- a/src/main/java/no/digipost/api/client/DigipostClientMock.java
+++ b/src/main/java/no/digipost/api/client/DigipostClientMock.java
@@ -46,9 +46,9 @@ import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import static no.digipost.api.client.DigipostClientConfig.DigipostClientConfigBuilder.newBuilder;
-import static no.digipost.http.client3.DigipostHttpClientDefaults.DEFAULT_TIMEOUTS_MS;
 
 /**
  * Instansierer en DigipostClient som ikke går mot faktiskt Digipost REST-api endepunkt og
@@ -65,9 +65,13 @@ public class DigipostClientMock {
     private static final int PORT = 6666;
 
     public DigipostClientMock() {
+        this(UnaryOperator.identity());
+    }
+
+    public DigipostClientMock(UnaryOperator<DigipostHttpClientSettings> clientCustomizer) {
         URI host = URI.create("http://localhost:" + PORT);
 
-        HttpClientBuilder httpClientBuilder = DigipostHttpClientFactory.createBuilder(DigipostHttpClientSettings.DEFAULT.timeouts(DEFAULT_TIMEOUTS_MS.all(0)));
+        HttpClientBuilder httpClientBuilder = DigipostHttpClientFactory.createBuilder(clientCustomizer.apply(DigipostHttpClientSettings.DEFAULT));
 
         apiService = new ApiServiceImpl(httpClientBuilder, PORT, null, host, null);
         apiService.buildApacheHttpClientBuilder();

--- a/src/main/java/no/digipost/api/client/MessageSender.java
+++ b/src/main/java/no/digipost/api/client/MessageSender.java
@@ -54,6 +54,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Duration.between;
 import static java.time.Duration.ofMinutes;
 import static java.util.Optional.empty;
@@ -109,13 +110,14 @@ public class MessageSender extends Communicator {
             ByteArrayOutputStream bao = new ByteArrayOutputStream();
             marshal(messageContext, singleChannelMessage, bao);
             ByteArrayBody attachment = new ByteArrayBody(bao.toByteArray(),
-                    ContentType.create(MediaTypes.DIGIPOST_MEDIA_TYPE_V7),"message");
+                    ContentType.create(MediaTypes.DIGIPOST_MEDIA_TYPE_V7, UTF_8), "message");
 
             MultipartEntityBuilder multipartEntity = MultipartEntityBuilder.create()
                     .setMode(HttpMultipartMode.STRICT)
                     .setMimeSubtype(DIGIPOST_MULTI_MEDIA_SUB_TYPE_V7)
                     .addPart(FormBodyPartBuilder.create("message", attachment)
                             .addField("Content-Disposition", "attachment;" + " filename=\"message\"")
+                            .addField("Content-Transfer-Encoding", UTF_8.displayName())
                             .build());
 
             for (Entry<Document, InputStream> documentAndContent : preparedDocuments.entrySet()) {


### PR DESCRIPTION
Use the parsing facility of Undertow to parse multipart requests in the Digipost mock instead of the ad-hoc flaky substring matching.

It is now possible to retrieve the actual content parts of a sent request, not just the content type.

