### PR TITLE
Multipart encoding bugfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>9.0.2</version>
+    <version>9.1-SNAPSHOT</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -543,7 +543,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>9.0.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>9.0.2.encodingbugfix-SNAPSHOT</version>
+    <version>9.0.2</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -543,7 +543,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>HEAD</tag>
+        <tag>9.0.2</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>9.1-SNAPSHOT</version>
+    <version>9.0.2.encodingbugfix-SNAPSHOT</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -202,11 +202,11 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.6.2</version>
+                    <version>3.7.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20</version>
+                    <version>2.20.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -218,7 +218,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.0.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -239,7 +239,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>2.5</version>
                     <configuration>
                         <generateBackupPoms>false</generateBackupPoms>
                     </configuration>

--- a/src/main/java/no/digipost/api/client/MessageSender.java
+++ b/src/main/java/no/digipost/api/client/MessageSender.java
@@ -117,7 +117,6 @@ public class MessageSender extends Communicator {
                     .setMimeSubtype(DIGIPOST_MULTI_MEDIA_SUB_TYPE_V7)
                     .addPart(FormBodyPartBuilder.create("message", attachment)
                             .addField("Content-Disposition", "attachment;" + " filename=\"message\"")
-                            .addField("Content-Transfer-Encoding", UTF_8.displayName())
                             .build());
 
             for (Entry<Document, InputStream> documentAndContent : preparedDocuments.entrySet()) {


### PR DESCRIPTION
Content-Transfer-Encoding headeren var ikke nødvendig for at Undertow-mocken skulle bruke riktig encoding for message-delen av multipart-requests.

Enda bedre er at når jeg fjerner Content-Transfer-Encoding så fungerer klientbiblioteket mot Digipost 🙈 