### PR TITLE
Remove PostType enum and usage

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -8,7 +8,6 @@ Licensed under Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.html
 
 This software includes third party software subject to the following licenses:
 
-  Antlr 3 Runtime under BSD licence
   Apache Commons Codec under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Lang under Apache License, Version 2.0
@@ -21,39 +20,24 @@ This software includes third party software subject to the following licenses:
   Bean Validation API under The Apache Software License, Version 2.0
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs under Bouncy Castle Licence
   Bouncy Castle Provider under Bouncy Castle Licence
-  Byte Buddy (without dependencies) under The Apache Software License, Version 2.0
-  Byte Buddy Java agent under The Apache Software License, Version 2.0
   ClassMate under The Apache Software License, Version 2.0
   Digipost API Client under The Apache Software License, Version 2.0
   Digipost Caching under The Apache Software License, Version 2.0
-  Digipost Digg under The Apache Software License, Version 2.0
   Digipost HTTP Client Builder under The Apache Software License, Version 2.0
   Digipost Printability Validator under The Apache Software License, Version 2.0
   digipost-data-types under The Apache Software License, Version 2.0
-  EqualsVerifier under The Apache Software License, Version 2.0
   Expression Language 3.0 under CDDL + GPLv2 with classpath exception
-  generics-resolver under The MIT License
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
   Hibernate Validator Engine under Apache License, Version 2.0
   Jackson datatype: JSR310 under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
   jackson-databind under The Apache Software License, Version 2.0
-  Java Hamcrest under BSD Licence 3
-  javaruntype under The Apache Software License, Version 2.0
-  Javassist under Mozilla Public License 1.1
   JBoss Logging 3 under Apache License, version 2.0
   JCL 1.2 implemented over SLF4J under MIT License
   Joda-Time under Apache 2
-  JUnit under Eclipse Public License 1.0
-  junit-quickcheck-core under The MIT License
-  junit-quickcheck-generators under The MIT License
-  mockito-core under The MIT License
   Motif under Apache License 2.0
-  Objenesis under Apache 2
-  OGNL - Object Graph Navigation Library under The Apache Software License, Version 2.0
   SLF4J API Module under MIT License
-  SLF4J Simple Binding under MIT License
   Undertow Core under Apache License Version 2.0
   XNIO API under Public Domain
   XNIO NIO Implementation under Public Domain

--- a/NOTICE
+++ b/NOTICE
@@ -9,7 +9,7 @@ Licensed under Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.html
 This software includes third party software subject to the following licenses:
 
   Antlr 3 Runtime under BSD licence
-  Apache Commons Codec under The Apache Software License, Version 2.0
+  Apache Commons Codec under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Lang under Apache License, Version 2.0
   Apache FontBox under Apache License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -192,12 +192,15 @@
                 <plugin>
                     <groupId>org.jasig.maven</groupId>
                     <artifactId>maven-notice-plugin</artifactId>
-                    <version>1.0.6.1</version>
+                    <version>1.1.0</version>
                     <configuration>
                         <noticeTemplate>${project.basedir}/src/main/notice/NOTICE.template</noticeTemplate>
                         <licenseMapping>
                             <param>${project.basedir}/src/main/notice/license-mappings.xml</param>
                         </licenseMapping>
+                        <excludeScopes>
+                            <excludeScope>test</excludeScope>
+                        </excludeScopes>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,10 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.0.0</version>
+                <configuration>
+                    <doclint>none</doclint>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>
@@ -515,25 +518,6 @@
                         </executions>
                     </plugin>
                 </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>doclint-java8-disable</id>
-            <activation>
-                <jdk>[1.8,</jdk>
-            </activation>
-
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <additionalparam>-Xdoclint:none</additionalparam>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
             </build>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
+            <version>4.5.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -64,12 +64,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.6</version>
+            <version>4.4.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.5.3</version>
+            <version>4.5.4</version>
         </dependency>
         <dependency>
             <groupId>no.digipost</groupId>
@@ -79,12 +79,12 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.6</version>
+            <version>3.7</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -122,13 +122,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.8.47</version>
+            <version>2.13.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>2.3.2</version>
+            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>9.1-SNAPSHOT</version>
+    <version>10.0</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -526,7 +526,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>HEAD</tag>
+        <tag>10.0</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -232,10 +232,6 @@
                     <version>3.0.2</version>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.6</version>
-                </plugin>
-                <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.0.0-M1</version>
                 </plugin>
@@ -250,7 +246,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.10.0</version>
+                    <version>0.11.0</version>
                     <configuration>
                         <newVersion>
                             <file><path>${project.build.directory}/${project.build.finalName}.${project.packaging}</path></file>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>10.0</version>
+    <version>10.1-SNAPSHOT</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -526,7 +526,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>10.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/api/client/representations/PrintDetails.java
+++ b/src/main/java/no/digipost/api/client/representations/PrintDetails.java
@@ -31,7 +31,6 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class PrintDetails {
 
-    public enum PostType {A, B}
     public enum NondeliverableHandling {RETURN_TO_SENDER, SHRED}
     public enum PrintColors {MONOCHROME, COLORS}
 
@@ -40,24 +39,27 @@ public class PrintDetails {
     protected PrintRecipient recipient;
     @XmlElement(name = "return-address", required = true)
     protected PrintRecipient returnAddress;
-    @XmlElement(name = "post-type", required = true)
-    protected PostType postType;
     @XmlElement(name = "color")
     protected PrintColors printColors;
     @XmlElement(name ="nondeliverable-handling")
     protected NondeliverableHandling nondeliverableHandling;
 
+    /**
+     * As of 2018, Posten is no longer separating between A and B priority. PostType will eventually be removed from the API.
+     * Until then, it is hardcoded to "A" to pass XSD validation, but is ignored by Digipost.
+     */
+    @XmlElement(name = "post-type", required = true)
+    private final String postType = "A";
 
     PrintDetails() {}
 
-    public PrintDetails(final PrintRecipient recipient, final PrintRecipient returnAddress, final PostType postType) {
-        this(recipient, returnAddress, postType, null, null);
+    public PrintDetails(final PrintRecipient recipient, final PrintRecipient returnAddress) {
+        this(recipient, returnAddress, null, null);
     }
 
-    public PrintDetails(final PrintRecipient recipient, final PrintRecipient returnAddress, final PostType postType, final PrintColors colors, final NondeliverableHandling nondeliverableHandling) {
+    public PrintDetails(final PrintRecipient recipient, final PrintRecipient returnAddress, final PrintColors colors, final NondeliverableHandling nondeliverableHandling) {
         this.recipient = recipient;
         this.returnAddress = returnAddress;
-        this.postType = postType;
         this.printColors = colors;
         this.nondeliverableHandling = nondeliverableHandling;
     }
@@ -68,10 +70,6 @@ public class PrintDetails {
 
     public PrintRecipient getReturnAddress() {
         return returnAddress;
-    }
-
-    public PostType getPostType() {
-        return postType;
     }
 
     public PrintColors getPrintColors() {

--- a/src/main/java/no/digipost/api/client/swing/DigipostSwingClient.java
+++ b/src/main/java/no/digipost/api/client/swing/DigipostSwingClient.java
@@ -29,7 +29,6 @@ import no.digipost.api.client.representations.NorwegianAddress;
 import no.digipost.api.client.representations.OrganisationNumber;
 import no.digipost.api.client.representations.PersonalIdentificationNumber;
 import no.digipost.api.client.representations.PrintDetails;
-import no.digipost.api.client.representations.PrintDetails.PostType;
 import no.digipost.api.client.representations.PrintRecipient;
 import no.digipost.api.client.representations.SmsNotification;
 
@@ -481,7 +480,7 @@ public class DigipostSwingClient {
                         NorwegianAddress norwegianAddress = new NorwegianAddress(addressline1, addressline2, zipCode, city);
                         PrintRecipient printRecipient, returnAddress;
                         returnAddress = printRecipient = new PrintRecipient(name, norwegianAddress);
-                        PrintDetails printDetails = new PrintDetails(printRecipient, returnAddress, PostType.B);
+                        PrintDetails printDetails = new PrintDetails(printRecipient, returnAddress);
 
                         MessageRecipient recipient;
                         if (fallbackToPrintCheckBox.isSelected()) {

--- a/src/test/java/no/digipost/api/client/DocumentsPreparerTest.java
+++ b/src/test/java/no/digipost/api/client/DocumentsPreparerTest.java
@@ -23,7 +23,6 @@ import no.digipost.api.client.representations.Message;
 import no.digipost.api.client.representations.Message.MessageBuilder;
 import no.digipost.api.client.representations.NorwegianAddress;
 import no.digipost.api.client.representations.PrintDetails;
-import no.digipost.api.client.representations.PrintDetails.PostType;
 import no.digipost.api.client.representations.PrintRecipient;
 import no.digipost.api.client.security.CryptoUtil;
 import no.digipost.api.client.util.DigipostPublicKey;
@@ -86,7 +85,7 @@ public class DocumentsPreparerTest {
     private final Document primaryDocument = new Document(UUID.randomUUID().toString(), "primary", PDF);
     private final Map<Document, InputStream> documents = new HashMap<Document, InputStream>() {{ put(primaryDocument, printablePdf1Page()); }};
     private final MessageBuilder messageBuilder = MessageBuilder.newMessage("m_id", primaryDocument).printDetails(
-            new PrintDetails(new PrintRecipient("Joe Schmoe", new NorwegianAddress("7845", "Far away")), new PrintRecipient("Dolly Parton", new NorwegianAddress("8942", "Farther away")), PostType.A));
+            new PrintDetails(new PrintRecipient("Joe Schmoe", new NorwegianAddress("7845", "Far away")), new PrintRecipient("Dolly Parton", new NorwegianAddress("8942", "Farther away"))));
 
     @Test
     public void failsIfMessageHasAnyDocumentsRequiringPreEncryptionAndNoEncryptionKeyIsSupplied() throws IOException {

--- a/src/test/java/no/digipost/api/client/MessageSenderTest.java
+++ b/src/test/java/no/digipost/api/client/MessageSenderTest.java
@@ -20,7 +20,26 @@ import no.digipost.api.client.delivery.MessageDeliverer;
 import no.digipost.api.client.delivery.OngoingDelivery.SendableForPrintOnly;
 import no.digipost.api.client.errorhandling.DigipostClientException;
 import no.digipost.api.client.errorhandling.ErrorCode;
-import no.digipost.api.client.representations.*;
+import no.digipost.api.client.representations.Channel;
+import no.digipost.api.client.representations.DigipostAddress;
+import no.digipost.api.client.representations.DigipostUri;
+import no.digipost.api.client.representations.Document;
+import no.digipost.api.client.representations.EncryptionKey;
+import no.digipost.api.client.representations.FileType;
+import no.digipost.api.client.representations.Identification;
+import no.digipost.api.client.representations.IdentificationResult;
+import no.digipost.api.client.representations.IdentificationResultWithEncryptionKey;
+import no.digipost.api.client.representations.Link;
+import no.digipost.api.client.representations.MayHaveSender;
+import no.digipost.api.client.representations.Message;
+import no.digipost.api.client.representations.MessageDelivery;
+import no.digipost.api.client.representations.MessageRecipient;
+import no.digipost.api.client.representations.MessageStatus;
+import no.digipost.api.client.representations.NorwegianAddress;
+import no.digipost.api.client.representations.PersonalIdentificationNumber;
+import no.digipost.api.client.representations.PrintDetails;
+import no.digipost.api.client.representations.PrintRecipient;
+import no.digipost.api.client.representations.SmsNotification;
 import no.digipost.api.client.representations.sender.SenderInformation;
 import no.digipost.api.client.security.CryptoUtil;
 import no.digipost.api.client.util.FakeEncryptionKey;
@@ -50,7 +69,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.time.Instant;
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static java.time.Duration.ofMillis;
@@ -59,26 +82,39 @@ import static java.time.ZonedDateTime.now;
 import static java.util.Arrays.asList;
 import static java.util.stream.Stream.concat;
 import static no.digipost.api.client.DigipostClientConfig.DigipostClientConfigBuilder.newBuilder;
-import static no.digipost.api.client.pdf.EksempelPdf.*;
+import static no.digipost.api.client.pdf.EksempelPdf.pdf20Pages;
+import static no.digipost.api.client.pdf.EksempelPdf.printablePdf1Page;
+import static no.digipost.api.client.pdf.EksempelPdf.printablePdf2Pages;
 import static no.digipost.api.client.representations.AuthenticationLevel.PASSWORD;
 import static no.digipost.api.client.representations.Channel.PRINT;
 import static no.digipost.api.client.representations.Message.MessageBuilder.newMessage;
 import static no.digipost.api.client.representations.MessageStatus.DELIVERED;
 import static no.digipost.api.client.representations.MessageStatus.DELIVERED_TO_PRINT;
-import static no.digipost.api.client.representations.PrintDetails.PostType.A;
 import static no.digipost.api.client.representations.Relation.GET_ENCRYPTION_KEY;
 import static no.digipost.api.client.representations.SensitivityLevel.NORMAL;
-import static no.digipost.api.client.representations.sender.SenderFeatureName.*;
+import static no.digipost.api.client.representations.sender.SenderFeatureName.DELIVERY_DIRECT_TO_PRINT;
+import static no.digipost.api.client.representations.sender.SenderFeatureName.DIGIPOST_DELIVERY;
+import static no.digipost.api.client.representations.sender.SenderFeatureName.PRINTVALIDATION_FONTS;
+import static no.digipost.api.client.representations.sender.SenderFeatureName.PRINTVALIDATION_MARGINS_LEFT;
+import static no.digipost.api.client.representations.sender.SenderFeatureName.PRINTVALIDATION_PDFVERSION;
 import static no.digipost.api.client.representations.sender.SenderStatus.VALID_SENDER;
-import static no.digipost.api.client.util.JAXBContextUtils.*;
+import static no.digipost.api.client.util.JAXBContextUtils.encryptionKeyContext;
+import static no.digipost.api.client.util.JAXBContextUtils.identificationResultWithEncryptionKeyContext;
+import static no.digipost.api.client.util.JAXBContextUtils.marshal;
+import static no.digipost.api.client.util.JAXBContextUtils.messageDeliveryContext;
 import static org.apache.http.HttpStatus.SC_CONFLICT;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 public class MessageSenderTest {
 
@@ -273,7 +309,7 @@ public class MessageSenderTest {
 
         MessageSender messageSender = new MessageSender(newBuilder().build(), api, DigipostClient.NOOP_EVENT_LOGGER, pdfValidator);
         Message message = newMessage(messageId, printDocument).attachments(printAttachments)
-                .recipient(new MessageRecipient(new DigipostAddress("asdfasd"), new PrintDetails(recipient, returnAddress, A))).build();
+                .recipient(new MessageRecipient(new DigipostAddress("asdfasd"), new PrintDetails(recipient, returnAddress))).build();
 
         documentAndContent.put(message.primaryDocument.uuid, DocumentContent.CreateMultiStreamContent(printablePdf1Page(), printablePdf1Page()));
         for (Document attachment : printAttachments) {
@@ -292,7 +328,7 @@ public class MessageSenderTest {
 
         List<Document> printAttachments = asList(new Document(UUID.randomUUID().toString(), "attachment", FileType.HTML).encrypt());
         Message message = newMessage(UUID.randomUUID().toString(), printDocument).attachments(printAttachments)
-                .recipient(new MessageRecipient(new DigipostAddress("asdfasd"), new PrintDetails(recipient, returnAddress, A))).build();
+                .recipient(new MessageRecipient(new DigipostAddress("asdfasd"), new PrintDetails(recipient, returnAddress))).build();
 
         documentAndContent.put(message.primaryDocument.uuid, DocumentContent.CreateMultiStreamContent(printablePdf1Page(), printablePdf2Pages()));
         for (Document attachment : printAttachments) {
@@ -321,7 +357,7 @@ public class MessageSenderTest {
 
         List<Document> printAttachments = asList(new Document(UUID.randomUUID().toString(), "attachment", FileType.HTML).encrypt());
         Message message = newMessage(UUID.randomUUID().toString(), printDocument).attachments(printAttachments)
-                .recipient(new MessageRecipient(new DigipostAddress("asdfasd"), new PrintDetails(recipient, returnAddress, A))).build();
+                .recipient(new MessageRecipient(new DigipostAddress("asdfasd"), new PrintDetails(recipient, returnAddress))).build();
 
         documentAndContent.put(message.primaryDocument.uuid, DocumentContent.CreateMultiStreamContent(printablePdf1Page(), printablePdf2Pages()));
         for (Document attachment : printAttachments) {
@@ -372,7 +408,7 @@ public class MessageSenderTest {
 
         LOG.debug("Tester direkte til print");
         MessageDeliverer deliverer = new MessageDeliverer(sender);
-        Message message = newMessage(messageId, printDocument).attachments(printAttachments).printDetails(new PrintDetails(recipient, returnAddress, A)).build();
+        Message message = newMessage(messageId, printDocument).attachments(printAttachments).printDetails(new PrintDetails(recipient, returnAddress)).build();
 
         SendableForPrintOnly sendable = deliverer
                 .createPrintOnlyMessage(message)

--- a/src/test/java/no/digipost/api/client/eksempelkode/FallbackTilPrintEksempel.java
+++ b/src/test/java/no/digipost/api/client/eksempelkode/FallbackTilPrintEksempel.java
@@ -16,7 +16,14 @@
 package no.digipost.api.client.eksempelkode;
 
 import no.digipost.api.client.DigipostClient;
-import no.digipost.api.client.representations.*;
+import no.digipost.api.client.representations.Document;
+import no.digipost.api.client.representations.Message;
+import no.digipost.api.client.representations.MessageRecipient;
+import no.digipost.api.client.representations.NorwegianAddress;
+import no.digipost.api.client.representations.PersonalIdentificationNumber;
+import no.digipost.api.client.representations.PrintDetails;
+import no.digipost.api.client.representations.PrintRecipient;
+import no.digipost.api.client.representations.SmsNotification;
 import org.apache.commons.io.FileUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
@@ -31,7 +38,6 @@ import static no.digipost.api.client.representations.AuthenticationLevel.PASSWOR
 import static no.digipost.api.client.representations.FileType.PDF;
 import static no.digipost.api.client.representations.Message.MessageBuilder.newMessage;
 import static no.digipost.api.client.representations.PrintDetails.NondeliverableHandling.RETURN_TO_SENDER;
-import static no.digipost.api.client.representations.PrintDetails.PostType.B;
 import static no.digipost.api.client.representations.PrintDetails.PrintColors.MONOCHROME;
 import static no.digipost.api.client.representations.SensitivityLevel.NORMAL;
 
@@ -68,7 +74,7 @@ public class FallbackTilPrintEksempel {
         Document primaryDocument = new Document(UUID.randomUUID().toString(), "Dokumentets emne", PDF, null, new SmsNotification(), null, PASSWORD, NORMAL);
 
         PrintDetails printDetails = new PrintDetails(new PrintRecipient("Mottakers navn", new NorwegianAddress("postnummer","Mottakers poststed")),
-                new PrintRecipient("Avsenders navn", new NorwegianAddress("postnummer", "Avsenders poststed")), B, MONOCHROME, RETURN_TO_SENDER);
+                new PrintRecipient("Avsenders navn", new NorwegianAddress("postnummer", "Avsenders poststed")), MONOCHROME, RETURN_TO_SENDER);
         String dinForsendelseId = UUID.randomUUID().toString();
         Message message = newMessage(dinForsendelseId, primaryDocument)
                 .recipient(new MessageRecipient(pin, printDetails))

--- a/src/test/java/no/digipost/api/client/eksempelkode/GithubPagesSendExamples.java
+++ b/src/test/java/no/digipost/api/client/eksempelkode/GithubPagesSendExamples.java
@@ -17,7 +17,22 @@ package no.digipost.api.client.eksempelkode;
 
 import no.digipost.api.client.DigipostClient;
 import no.digipost.api.client.DigipostClientConfig;
-import no.digipost.api.client.representations.*;
+import no.digipost.api.client.representations.AuthenticationLevel;
+import no.digipost.api.client.representations.Document;
+import no.digipost.api.client.representations.FileType;
+import no.digipost.api.client.representations.Identification;
+import no.digipost.api.client.representations.IdentificationResult;
+import no.digipost.api.client.representations.Invoice;
+import no.digipost.api.client.representations.Message;
+import no.digipost.api.client.representations.MessageDelivery;
+import no.digipost.api.client.representations.MessageRecipient;
+import no.digipost.api.client.representations.NameAndAddress;
+import no.digipost.api.client.representations.NorwegianAddress;
+import no.digipost.api.client.representations.PersonalIdentificationNumber;
+import no.digipost.api.client.representations.PrintDetails;
+import no.digipost.api.client.representations.PrintRecipient;
+import no.digipost.api.client.representations.SensitivityLevel;
+import no.digipost.api.client.representations.SmsNotification;
 import no.digipost.api.datatypes.types.Appointment;
 import no.digipost.api.datatypes.types.AppointmentAddress;
 import no.digipost.api.datatypes.types.Info;
@@ -31,7 +46,6 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -154,7 +168,7 @@ public class GithubPagesSendExamples {
 
         PrintDetails printDetails = new PrintDetails(
                 new PrintRecipient("Ola Nordmann", new NorwegianAddress("Prinsensveien 123", "0460", "Oslo")),
-                new PrintRecipient("Norgesbedriften", new NorwegianAddress("Akers Àle 2", "0400", "Oslo")), PrintDetails.PostType.B, PrintDetails.PrintColors.MONOCHROME, PrintDetails.NondeliverableHandling.RETURN_TO_SENDER);
+                new PrintRecipient("Norgesbedriften", new NorwegianAddress("Akers Àle 2", "0400", "Oslo")), PrintDetails.PrintColors.MONOCHROME, PrintDetails.NondeliverableHandling.RETURN_TO_SENDER);
 
         Message message = Message.MessageBuilder.newMessage(UUID2, primaryDocument)
                 .recipient(new MessageRecipient(pin, printDetails))

--- a/src/test/java/no/digipost/api/client/representations/MessageTest.java
+++ b/src/test/java/no/digipost/api/client/representations/MessageTest.java
@@ -102,9 +102,9 @@ public class MessageTest {
                 .digipostAddress(new DigipostAddress("Test2"))
                 .senderId(1L).deliveryTime(ZonedDateTime.now()).invoiceReference("Invoice")
                 .recipient(new MessageRecipient(new DigipostAddress("TestAdress"), new PrintDetails(
-                        new PrintRecipient("Test", new NorwegianAddress("Bajs", "Korv", "Zip", "Zop"))
-                        , new PrintRecipient("Test", new NorwegianAddress("Bajs", "Korv", "Zip", "Zop")),
-                        PrintDetails.PostType.A, PrintDetails.PrintColors.COLORS, PrintDetails.NondeliverableHandling.RETURN_TO_SENDER))).build();
+                        new PrintRecipient("Test", new NorwegianAddress("Bajs", "Korv", "Zip", "Zop")),
+                        new PrintRecipient("Test", new NorwegianAddress("Bajs", "Korv", "Zip", "Zop")),
+                        PrintDetails.PrintColors.COLORS, PrintDetails.NondeliverableHandling.RETURN_TO_SENDER))).build();
 
         Message copyOfMessageWithPrintDetailsOnly = Message.copyMessageWithOnlyPrintDetails(message);
 
@@ -117,7 +117,6 @@ public class MessageTest {
         assertNull(copyOfMessageWithPrintDetailsOnly.recipient.organisationNumber);
         assertNull(copyOfMessageWithPrintDetailsOnly.recipient.personalIdentificationNumber);
         assertThat(copyOfMessageWithPrintDetailsOnly.recipient.printDetails.nondeliverableHandling, is(message.recipient.printDetails.nondeliverableHandling));
-        assertThat(copyOfMessageWithPrintDetailsOnly.recipient.printDetails.postType, is(message.recipient.printDetails.postType));
         assertThat(copyOfMessageWithPrintDetailsOnly.recipient.printDetails.printColors, is(message.recipient.printDetails.printColors));
 
         assertThat("When copying to only print, the file type should be set to pdf",

--- a/src/test/java/no/digipost/api/client/representations/ObjectBuilder.java
+++ b/src/test/java/no/digipost/api/client/representations/ObjectBuilder.java
@@ -22,7 +22,6 @@ import static no.digipost.api.client.representations.AuthenticationLevel.PASSWOR
 import static no.digipost.api.client.representations.FileType.PDF;
 import static no.digipost.api.client.representations.Message.MessageBuilder.newMessage;
 import static no.digipost.api.client.representations.PrintDetails.NondeliverableHandling.RETURN_TO_SENDER;
-import static no.digipost.api.client.representations.PrintDetails.PostType.B;
 import static no.digipost.api.client.representations.PrintDetails.PrintColors.MONOCHROME;
 import static no.digipost.api.client.representations.SensitivityLevel.NORMAL;
 
@@ -49,7 +48,7 @@ public class ObjectBuilder {
 
     public static Message newPrintMessage(final String messageId, final PrintRecipient recipient, final PrintRecipient returnAddress) {
         return newMessage(messageId, new Document(UUID.randomUUID().toString(), "emne", PDF, null, new SmsNotification(), null, PASSWORD, NORMAL))
-                .recipient(new MessageRecipient(new PrintDetails(recipient, returnAddress, B, MONOCHROME, RETURN_TO_SENDER)))
+                .recipient(new MessageRecipient(new PrintDetails(recipient, returnAddress, MONOCHROME, RETURN_TO_SENDER)))
                 .build();
     }
 

--- a/src/test/java/no/digipost/api/client/representations/XsdValidationTest.java
+++ b/src/test/java/no/digipost/api/client/representations/XsdValidationTest.java
@@ -44,7 +44,6 @@ import static no.digipost.api.client.representations.ErrorType.CLIENT_DATA;
 import static no.digipost.api.client.representations.FileType.PDF;
 import static no.digipost.api.client.representations.Message.MessageBuilder.newMessage;
 import static no.digipost.api.client.representations.MessageStatus.DELIVERED;
-import static no.digipost.api.client.representations.PrintDetails.PostType.B;
 import static no.digipost.api.client.representations.SensitivityLevel.NORMAL;
 import static no.digipost.api.client.representations.XmlTestHelper.marshallValidateAndUnmarshall;
 import static org.hamcrest.Matchers.is;
@@ -139,7 +138,7 @@ public class XsdValidationTest {
         Message message = newMessage(randomUUID().toString(),
                         new Document(randomUUID().toString(), "subject", PDF, null, new SmsNotification(), null, PASSWORD, NORMAL)
                 )
-                .recipient(new MessageRecipient(new PrintDetails(address, address, B)))
+                .recipient(new MessageRecipient(new PrintDetails(address, address)))
                 .build();
         marshallValidateAndUnmarshall(message);
     }
@@ -150,7 +149,7 @@ public class XsdValidationTest {
         Message message = newMessage(randomUUID().toString(),
                         new Document(randomUUID().toString(), "subject", PDF, null, new SmsNotification(), null, PASSWORD, NORMAL)
                 )
-                .recipient(new MessageRecipient(new PrintDetails(address, address, B)))
+                .recipient(new MessageRecipient(new PrintDetails(address, address)))
                 .build();
         marshallValidateAndUnmarshall(message);
     }
@@ -161,7 +160,7 @@ public class XsdValidationTest {
         Message message = newMessage(randomUUID().toString(),
                         new Document(randomUUID().toString(), "subject", PDF, null, new SmsNotification(), null, PASSWORD, NORMAL)
                 )
-                .recipient(new MessageRecipient(new PrintDetails(address, address, B)))
+                .recipient(new MessageRecipient(new PrintDetails(address, address)))
                 .build();
         marshallValidateAndUnmarshall(message);
     }


### PR DESCRIPTION
As of 2018, Posten is no longer separating between A and B priority mail. `post-type` will eventually be removed from the API. For now, `print-details` gets a hardcoded `"A"` as `post-type` until an updated XSD is available, but it is ignored by Digipost.

This will become a `v10`-release, as the Java API is changed to not include PostType.