### PR TITLE
Correct encoding of search string in URL-path and signature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>10.1-SNAPSHOT</version>
+    <version>10.1</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -526,7 +526,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>HEAD</tag>
+        <tag>10.1</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>10.1</version>
+    <version>10.2-SNAPSHOT</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -526,7 +526,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>10.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/api/client/representations/Recipient.java
+++ b/src/main/java/no/digipost/api/client/representations/Recipient.java
@@ -94,4 +94,18 @@ public class Recipient extends Representation {
         this.links = links;
     }
 
+    @Override
+    public String toString() {
+        return "Recipient{" +
+                "firstname='" + firstname + '\'' +
+                ", middlename='" + middlename + '\'' +
+                ", lastname='" + lastname + '\'' +
+                ", digipostAddress='" + digipostAddress + '\'' +
+                ", mobileNumber='" + mobileNumber + '\'' +
+                ", organisationNumber='" + organisationNumber + '\'' +
+                ", organisationName='" + organisationName + '\'' +
+                ", addresses=" + addresses +
+                ", links=" + links +
+                '}';
+    }
 }

--- a/src/main/java/no/digipost/api/client/representations/Recipients.java
+++ b/src/main/java/no/digipost/api/client/representations/Recipients.java
@@ -61,4 +61,12 @@ public class Recipients extends Representation {
     protected void setLink(final List<Link> links) {
         this.links = links;
     }
+
+    @Override
+    public String toString() {
+        return "Recipients{" +
+                "recipients=" + recipients +
+                ", links=" + links +
+                '}';
+    }
 }

--- a/src/main/java/no/digipost/api/client/security/ClientRequestToSign.java
+++ b/src/main/java/no/digipost/api/client/security/ClientRequestToSign.java
@@ -49,7 +49,7 @@ public class ClientRequestToSign implements RequestToSign {
     @Override
     public String getPath() {
         try {
-            String path = new URI(clientRequest.getRequestLine().getUri()).getPath();
+            String path = new URI(clientRequest.getRequestLine().getUri()).getRawPath();
             return path != null ? path : "";
         } catch (URISyntaxException e) {
             throw new RuntimeException(e.getMessage(), e);

--- a/src/main/java/no/digipost/api/client/util/ExceptionUtils.java
+++ b/src/main/java/no/digipost/api/client/util/ExceptionUtils.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.util;
+
+public class ExceptionUtils {
+
+    public static String exceptionNameAndMessage(Throwable t) {
+        return t.getClass().getSimpleName() + ": '" + t.getMessage() + "'";
+    }
+}

--- a/src/main/java/no/digipost/api/client/util/JAXBContextUtils.java
+++ b/src/main/java/no/digipost/api/client/util/JAXBContextUtils.java
@@ -24,6 +24,8 @@ import javax.xml.bind.JAXBException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import static no.digipost.api.client.util.ExceptionUtils.exceptionNameAndMessage;
+
 public class JAXBContextUtils {
     public static final JAXBContext entryPointContext = initContext(EntryPoint.class);
     public static final JAXBContext errorMessageContext = initContext(ErrorMessage.class);
@@ -50,7 +52,7 @@ public class JAXBContextUtils {
         try {
             context.createMarshaller().marshal(objectToMarshall, outputStream);
         } catch (JAXBException e) {
-            throw new RuntimeException("Failed when trying to marshal object to outputstream", e);
+            throw new RuntimeException("Failed when trying to marshal object to outputstream. Cause: " + exceptionNameAndMessage(e), e);
         }
     }
 
@@ -58,7 +60,7 @@ public class JAXBContextUtils {
         try {
             return type.cast(context.createUnmarshaller().unmarshal(inputStream));
         } catch (JAXBException e) {
-            throw new RuntimeException("Failed when trying to unmarshal inputstream to object", e);
+            throw new RuntimeException("Failed when trying to unmarshal inputstream to object. Cause: " + exceptionNameAndMessage(e), e);
         }
     }
 }


### PR DESCRIPTION
Since search queries are part of the URL they must be encoded in accordance with [rfc1738](https://tools.ietf.org/html/rfc1738)

This PR fixes both the url-encoding and using the encoded url in the signature.