### PR TITLE
Returkonvolutt

### DIFF
--- a/src/main/java/no/digipost/api/client/representations/PrintDetails.java
+++ b/src/main/java/no/digipost/api/client/representations/PrintDetails.java
@@ -29,7 +29,7 @@ import java.util.List;
     "postType",
     "printColors",
     "nondeliverableHandling",
-    "instruction"
+    "printInstructions"
 })
 public class PrintDetails {
 
@@ -46,8 +46,8 @@ public class PrintDetails {
     @XmlElement(name ="nondeliverable-handling")
     protected NondeliverableHandling nondeliverableHandling;
 
-    @XmlElement
-    protected List<PrintInstruction> instruction;
+    @XmlElement(name = "print-instructions")
+    protected PrintInstructions printInstructions;
 
     /**
      * As of 2018, Posten is no longer separating between A and B priority. PostType will eventually be removed from the API.
@@ -69,8 +69,10 @@ public class PrintDetails {
         this.nondeliverableHandling = nondeliverableHandling;
     }
 
-    public void setInstruction(List<PrintInstruction> instruction) {
-        this.instruction = instruction;
+    public void setInstruction(List<PrintInstruction> instructions) {
+        if (!instructions.isEmpty()) {
+            this.printInstructions = new PrintInstructions(instructions);
+        }
     }
 
     public PrintRecipient getRecipient() {

--- a/src/main/java/no/digipost/api/client/representations/PrintDetails.java
+++ b/src/main/java/no/digipost/api/client/representations/PrintDetails.java
@@ -19,6 +19,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import java.util.List;
 
 
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -27,7 +28,8 @@ import javax.xml.bind.annotation.XmlType;
     "returnAddress",
     "postType",
     "printColors",
-    "nondeliverableHandling"
+    "nondeliverableHandling",
+    "instruction"
 })
 public class PrintDetails {
 
@@ -43,6 +45,9 @@ public class PrintDetails {
     protected PrintColors printColors;
     @XmlElement(name ="nondeliverable-handling")
     protected NondeliverableHandling nondeliverableHandling;
+
+    @XmlElement
+    protected List<PrintInstruction> instruction;
 
     /**
      * As of 2018, Posten is no longer separating between A and B priority. PostType will eventually be removed from the API.
@@ -62,6 +67,10 @@ public class PrintDetails {
         this.returnAddress = returnAddress;
         this.printColors = colors;
         this.nondeliverableHandling = nondeliverableHandling;
+    }
+
+    public void setInstruction(List<PrintInstruction> instruction) {
+        this.instruction = instruction;
     }
 
     public PrintRecipient getRecipient() {

--- a/src/main/java/no/digipost/api/client/representations/PrintInstruction.java
+++ b/src/main/java/no/digipost/api/client/representations/PrintInstruction.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.representations;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "print-instruction", propOrder = {
+        "key",
+        "value"
+})
+public class PrintInstruction {
+
+    @XmlElement(required = true)
+    private String key;
+
+    @XmlElement(required = true)
+    private String value;
+
+    public PrintInstruction() {}
+
+    public PrintInstruction(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+}

--- a/src/main/java/no/digipost/api/client/representations/PrintInstructions.java
+++ b/src/main/java/no/digipost/api/client/representations/PrintInstructions.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.representations;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.List;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "print-instructions", propOrder = {
+        "printInstruction"
+})
+public class PrintInstructions {
+
+    @XmlElement(name = "print-instruction", required = true)
+    private List<PrintInstruction> printInstruction;
+
+    public PrintInstructions() { }
+
+    public PrintInstructions(List<PrintInstruction> printInstruction) {
+        this.printInstruction = printInstruction;
+    }
+}

--- a/src/main/resources/xsd/api_v7.xsd
+++ b/src/main/resources/xsd/api_v7.xsd
@@ -496,8 +496,16 @@
             <xsd:element name="post-type" type="post-type" minOccurs="1" maxOccurs="1" />
             <xsd:element name="color" type="print-colors" minOccurs="0" maxOccurs="1" default="MONOCHROME"/>
             <xsd:element name="nondeliverable-handling" type="nondeliverable-handling" minOccurs="0" maxOccurs="1" default="RETURN_TO_SENDER"/>
+            <xsd:element name="instruction" type="print-instruction" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
+
+	<xsd:complexType name="print-instruction">
+		<xsd:sequence>
+			<xsd:element name="key" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="value" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
 
     <xsd:simpleType name="post-type">
         <xsd:annotation>

--- a/src/main/resources/xsd/api_v7.xsd
+++ b/src/main/resources/xsd/api_v7.xsd
@@ -496,16 +496,22 @@
             <xsd:element name="post-type" type="post-type" minOccurs="1" maxOccurs="1" />
             <xsd:element name="color" type="print-colors" minOccurs="0" maxOccurs="1" default="MONOCHROME"/>
             <xsd:element name="nondeliverable-handling" type="nondeliverable-handling" minOccurs="0" maxOccurs="1" default="RETURN_TO_SENDER"/>
-            <xsd:element name="instruction" type="print-instruction" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="print-instructions" type="print-instructions" minOccurs="0" maxOccurs="1"/>
         </xsd:sequence>
     </xsd:complexType>
 
-	<xsd:complexType name="print-instruction">
-		<xsd:sequence>
-			<xsd:element name="key" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="value" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-		</xsd:sequence>
-	</xsd:complexType>
+    <xsd:complexType name="print-instructions">
+        <xsd:sequence>
+            <xsd:element name="print-instruction" type="print-instruction" minOccurs="1" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="print-instruction">
+        <xsd:sequence>
+            <xsd:element name="key" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="value" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
 
     <xsd:simpleType name="post-type">
         <xsd:annotation>

--- a/src/test/java/no/digipost/api/client/representations/XsdValidationTest.java
+++ b/src/test/java/no/digipost/api/client/representations/XsdValidationTest.java
@@ -166,6 +166,21 @@ public class XsdValidationTest {
     }
 
     @Test
+    public void validate_print_message_with_print_instructions() {
+        PrintRecipient address = new PrintRecipient("name", new NorwegianAddress("1234", "Oslo"));
+
+        PrintDetails printDetails = new PrintDetails(address, address);
+        printDetails.setInstruction(Arrays.asList(new PrintInstruction("returkonvolutt", "true")));
+
+        Message message = newMessage(randomUUID().toString(),
+                new Document(randomUUID().toString(), "subject", PDF, null, new SmsNotification(), null, PASSWORD, NORMAL)
+        )
+                .recipient(new MessageRecipient(printDetails))
+                .build();
+        marshallValidateAndUnmarshall(message);
+    }
+
+    @Test
     public void validateDocumentEvents() {
         DocumentEvent openedEvent = new DocumentEvent(randomUUID().toString(), OPENED, ZonedDateTime.now(), ZonedDateTime.now());
 


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Helse Midt-Norge (HEMIT) ønsker å kunne be Parajett om å legge ved en returkonvolutt i forsendelsene. For å kunne imøtekomme dette legger vi til et nytt element i printdetaljene som vi kaller printinstruksjoner.

### 🏆 Interessante highlights

Vi gjør det mulig å legge ved vilkårlig antall ekstra printinstruksjoner. 

### ⚙️ Avhengigheter 

⚠️ Må prodsettes etter at digipost api har fått støtte for funksjonaliteten (digipost/digipost#739) 

