### PR TITLE
Bugfix and remove keyId from user account encryption key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>10.6</version>
+    <version>10.7-SNAPSHOT</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -507,7 +507,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>10.6</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>10.6-SNAPSHOT</version>
+    <version>10.6</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -507,7 +507,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>HEAD</tag>
+        <tag>10.6</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/api/client/representations/accounts/EncryptionKey.java
+++ b/src/main/java/no/digipost/api/client/representations/accounts/EncryptionKey.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.representations.accounts;
+
+import javax.xml.bind.annotation.XmlValue;
+
+public class EncryptionKey {
+
+    @XmlValue
+    private final String value;
+
+    public EncryptionKey(String value) {
+        this.value = value;
+    }
+
+    private EncryptionKey() {
+        this(null);
+    }
+
+    public String getValuePEMFormatted() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "EncryptionKey{" +
+                "value='" + value + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/no/digipost/api/client/representations/accounts/UserAccount.java
+++ b/src/main/java/no/digipost/api/client/representations/accounts/UserAccount.java
@@ -29,13 +29,13 @@ public class UserAccount {
     @XmlElement(name = "encryption-key")
     private final EncryptionKey encryptionKey;
 
-    public UserAccount(DigipostAddress digipostAddress, EncryptionKey encryptionKey, String resultCode, String resultDescription) {
+    public UserAccount(DigipostAddress digipostAddress, EncryptionKey encryptionKey) {
         this.digipostAddress = digipostAddress;
         this.encryptionKey = encryptionKey;
     }
 
     private UserAccount() {
-        this(null, null, null, null);
+        this(null, null);
     }
 
     public DigipostAddress getDigipostAddress() {

--- a/src/main/java/no/digipost/api/client/representations/accounts/UserAccount.java
+++ b/src/main/java/no/digipost/api/client/representations/accounts/UserAccount.java
@@ -16,7 +16,6 @@
 package no.digipost.api.client.representations.accounts;
 
 import no.digipost.api.client.representations.DigipostAddress;
-import no.digipost.api.client.representations.EncryptionKey;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;

--- a/src/main/resources/xsd/api_v7.xsd
+++ b/src/main/resources/xsd/api_v7.xsd
@@ -1136,7 +1136,7 @@
     <xsd:complexType name="user-account">
         <xsd:sequence>
             <xsd:element name="digipost-address" type="xsd:string" minOccurs="1" maxOccurs="1" />
-            <xsd:element name="encryption-key" type="encryption-key" minOccurs="1" maxOccurs="1" />
+            <xsd:element name="encryption-key" type="xsd:string" minOccurs="1" maxOccurs="1" />
         </xsd:sequence>
     </xsd:complexType>
 


### PR DESCRIPTION
Changes:

* Remove keyId from UserAccount -> EncryptionKey (unused)
  - Results in a new type so that it does not interfere with other uses of the other EncryptionKey type
* Remove unused parameters from UserAccount constructor