### PR TITLE
Fjerner unødvendig kall til `getClass()`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>10.9</version>
+    <version>10.10-SNAPSHOT</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -507,7 +507,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>10.9</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>
-    <version>10.9-SNAPSHOT</version>
+    <version>10.9</version>
     <name>Digipost API Client</name>
     <description>Java library for interacting with the Digipost REST API</description>
 
@@ -507,7 +507,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-api-client-java.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
-        <tag>HEAD</tag>
+        <tag>10.9</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/api/client/DigipostClientMock.java
+++ b/src/main/java/no/digipost/api/client/DigipostClientMock.java
@@ -94,7 +94,7 @@ public class DigipostClientMock {
     public static KeyPair getKeyPair(final String alias, final String password) {
         try {
             KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-            keystore.load(DigipostClientMock.class.getClass().getResourceAsStream("/mockKeystore.jks"), KEY_STORE_PASSWORD.toCharArray());
+            keystore.load(DigipostClientMock.class.getResourceAsStream("/mockKeystore.jks"), KEY_STORE_PASSWORD.toCharArray());
 
             Key key = keystore.getKey(alias, password.toCharArray());
             Certificate cert = keystore.getCertificate(alias);


### PR DESCRIPTION
Dette fører til at vi får `null` når vi henter ut keystoret på JDK10 😔