### PR TITLE
Ta i bruk siste super pom og siste versjon av action-maven-publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set release version
         run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:11}"-SNAPSHOT")
       - name: Build and deploy to Sonatype snapshot
-        uses: digipost/action-maven-publish@master
+        uses: digipost/action-maven-publish@1.1.0
         with:
           sonatype_secrets: ${{ secrets.sonatype_secrets }}
           release_version: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set release version
         run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
       - name: Release to Central Repository
-        uses: digipost/action-maven-publish@1.0.0
+        uses: digipost/action-maven-publish@1.1.0
         with:
           sonatype_secrets: ${{ secrets.sonatype_secrets }}
           release_version: ${{ env.RELEASE_VERSION }}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>digipost-open-super-pom</artifactId>
-        <version>4</version>
+        <version>6</version>
     </parent>
 
     <artifactId>digipost-api-client-java</artifactId>


### PR DESCRIPTION
Grunnen er at vi må ha siste versjon av parent pom
for å få med pinentry loopback for å hente ut gpg-nøkkel for å signere releaser