### PR TITLE
Added email recipient in message

### DIFF
--- a/src/main/java/no/digipost/api/client/representations/EmailDetails.java
+++ b/src/main/java/no/digipost/api/client/representations/EmailDetails.java
@@ -23,28 +23,19 @@ import javax.xml.bind.annotation.XmlType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "email-details", propOrder = {
-    "emailAddress",
-    "content",
-    "subject"
+    "emailAddress"
 })
 public class EmailDetails
 {
 
     @XmlElement(name = "email-address", required = true)
     protected String emailAddress;
-    @XmlElement(required = true)
-    protected String content;
-    @XmlElement(required = true)
-    protected String subject;
 
     public EmailDetails() {
-
     }
 
-    public EmailDetails(final String emailAddress, final String content, final String subject) {
+    public EmailDetails(final String emailAddress) {
         this.emailAddress = emailAddress;
-        this.content = content;
-        this.subject = subject;
     }
 
     public String getEmailAddress() {
@@ -54,26 +45,6 @@ public class EmailDetails
 
     public void setEmailAddress(String value) {
         this.emailAddress = value;
-    }
-
-
-    public String getContent() {
-        return content;
-    }
-
-
-    public void setContent(String value) {
-        this.content = value;
-    }
-
-
-    public String getSubject() {
-        return subject;
-    }
-
-
-    public void setSubject(String value) {
-        this.subject = value;
     }
 
 }

--- a/src/main/java/no/digipost/api/client/representations/EmailDetails.java
+++ b/src/main/java/no/digipost/api/client/representations/EmailDetails.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.representations;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "email-details", propOrder = {
+    "emailAddress",
+    "content",
+    "subject"
+})
+public class EmailDetails
+{
+
+    @XmlElement(name = "email-address", required = true)
+    protected String emailAddress;
+    @XmlElement(required = true)
+    protected String content;
+    @XmlElement(required = true)
+    protected String subject;
+
+    public EmailDetails() {
+
+    }
+
+    public EmailDetails(final String emailAddress, final String content, final String subject) {
+        this.emailAddress = emailAddress;
+        this.content = content;
+        this.subject = subject;
+    }
+
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+
+    public void setEmailAddress(String value) {
+        this.emailAddress = value;
+    }
+
+
+    public String getContent() {
+        return content;
+    }
+
+
+    public void setContent(String value) {
+        this.content = value;
+    }
+
+
+    public String getSubject() {
+        return subject;
+    }
+
+
+    public void setSubject(String value) {
+        this.subject = value;
+    }
+
+}

--- a/src/main/java/no/digipost/api/client/representations/Message.java
+++ b/src/main/java/no/digipost/api/client/representations/Message.java
@@ -219,7 +219,7 @@ public class Message implements MayHaveSender {
 
         return new Message(messageToCopy.messageId, messageToCopy.senderId, messageToCopy.senderOrganization,
                 null, null, null, null, messageToCopy.deliveryTime, messageToCopy.invoiceReference,
-                messageToCopy.primaryDocument.copyDocumentAndSetDigipostFileTypeToPdf(), tmpAttachments, messageToCopy.recipient.getPrintDetails(), null, null);
+                messageToCopy.primaryDocument.copyDocumentAndSetDigipostFileTypeToPdf(), tmpAttachments, messageToCopy.recipient.getPrintDetails(), null, null, null);
     }
 
     public static Message copyMessageWithOnlyDigipostDetails(Message messageToCopy){
@@ -227,24 +227,26 @@ public class Message implements MayHaveSender {
                 messageToCopy.recipient.nameAndAddress, messageToCopy.recipient.digipostAddress,
                 messageToCopy.recipient.personalIdentificationNumber, messageToCopy.recipient.organisationNumber,
                 messageToCopy.deliveryTime, messageToCopy.invoiceReference, messageToCopy.primaryDocument,
-                messageToCopy.attachments, null, messageToCopy.recipient.bankAccountNumber, messageToCopy.printIfUnread);
+                messageToCopy.attachments, null, messageToCopy.recipient.bankAccountNumber, messageToCopy.printIfUnread, messageToCopy.recipient.emailDetails);
     }
 
     private Message(final String messageId, final Long senderId, final SenderOrganization senderOrganization,
                     final NameAndAddress nameAndAddress, final String digipostAddress, String personalIdentificationNumber,
                     final String organisationNumber, final ZonedDateTime deliveryTime, final String invoiceReference,
-                    final Document primaryDocument, final List<Document> attachments, final PrintDetails printDetails, final String bankAccountNumber, PrintIfUnread printIfUnread){
+                    final Document primaryDocument, final List<Document> attachments, final PrintDetails printDetails,
+                    final String bankAccountNumber, PrintIfUnread printIfUnread, final EmailDetails emailDetails){
         this.messageId = messageId;
         this.senderId = senderId;
         this.senderOrganization = senderOrganization;
         MessageRecipient recipient = new MessageRecipient(nameAndAddress, digipostAddress,
-                personalIdentificationNumber, organisationNumber, printDetails, bankAccountNumber);
+                personalIdentificationNumber, organisationNumber, printDetails, bankAccountNumber, emailDetails);
         this.recipient = recipient;
         this.deliveryTime = deliveryTime;
         this.invoiceReference = invoiceReference;
         this.primaryDocument = primaryDocument;
         this.attachments = attachments;
         this.printIfUnread = printIfUnread;
+
     }
 
 

--- a/src/main/java/no/digipost/api/client/representations/MessageRecipient.java
+++ b/src/main/java/no/digipost/api/client/representations/MessageRecipient.java
@@ -54,13 +54,14 @@ public class MessageRecipient {
     }
 
     MessageRecipient(NameAndAddress nameAndAddress, String digipostAddress, String personalIdentificationNumber,
-                            String organisationNumber, PrintDetails printDetails, String bankAccountNumber){
+                            String organisationNumber, PrintDetails printDetails, String bankAccountNumber, EmailDetails emailDetails){
         this.nameAndAddress = nameAndAddress;
         this.digipostAddress = digipostAddress;
         this.personalIdentificationNumber = personalIdentificationNumber;
         this.organisationNumber = organisationNumber;
         this.printDetails = printDetails;
         this.bankAccountNumber = bankAccountNumber;
+        this.emailDetails = emailDetails;
     }
 
     public MessageRecipient(final PersonalIdentificationNumber id) {

--- a/src/main/java/no/digipost/api/client/representations/MessageRecipient.java
+++ b/src/main/java/no/digipost/api/client/representations/MessageRecipient.java
@@ -30,7 +30,8 @@ import javax.xml.bind.annotation.XmlType;
         "personalIdentificationNumber",
         "organisationNumber",
         "printDetails",
-        "bankAccountNumber"
+        "bankAccountNumber",
+        "emailDetails"
 })
 public class MessageRecipient {
 
@@ -46,6 +47,8 @@ public class MessageRecipient {
     protected PrintDetails printDetails;
     @XmlElement(name = "bank-account-number", nillable = false)
     protected String bankAccountNumber;
+    @XmlElement(name = "email-details", nillable = false)
+    protected EmailDetails emailDetails;
 
     public MessageRecipient() {
     }
@@ -98,6 +101,10 @@ public class MessageRecipient {
     public MessageRecipient(final OrganisationNumber organisationNumber, final PrintDetails printDetails) {
         this(organisationNumber);
         this.printDetails = printDetails;
+    }
+
+    public MessageRecipient(final EmailDetails emailDetails) {
+        this.emailDetails = emailDetails;
     }
 
     public MessageRecipient(final PrintDetails printDetails) {

--- a/src/main/resources/xsd/api_v7.xsd
+++ b/src/main/resources/xsd/api_v7.xsd
@@ -1293,4 +1293,10 @@
         </xsd:sequence>
     </xsd:complexType>
 
+    <xsd:complexType name="email-details">
+        <xsd:sequence>
+            <xsd:element name="email-address" minOccurs="1" maxOccurs="1" type="xsd:string"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
 </xsd:schema>

--- a/src/test/java/no/digipost/api/client/representations/MessageTest.java
+++ b/src/test/java/no/digipost/api/client/representations/MessageTest.java
@@ -81,7 +81,7 @@ public class MessageTest {
         }
 
         Field[] recipientFields = MessageRecipient.class.getDeclaredFields();
-        assertThat(recipientFields.length, is(6));
+        assertThat(recipientFields.length, is(7));
 
         String[] allFieldsThatAreUsedForCopyInMessageRecipient = new String[]{"nameAndAddress", "digipostAddress", "personalIdentificationNumber",
                 "organisationNumber", "printDetails"};


### PR DESCRIPTION
In certain cases senders need to be able to request sending of email message through the Digipost API.

Are the fields in EmailDetails sufficient, or are we missing something?