### PR TITLE
Support for retrieving peppol message status from Digipost

### DIFF
--- a/src/main/java/no/digipost/api/client/DigipostClient.java
+++ b/src/main/java/no/digipost/api/client/DigipostClient.java
@@ -202,6 +202,10 @@ public class DigipostClient {
         return documentApi.getDocumentStatus(senderId, uuid);
     }
 
+    public DocumentStatus getPeppolStatus(SenderId senderId, UUID uuid) {
+        return  documentApi.getPeppolStatus(senderId, uuid);
+    }
+
     public InputStream getContent(String path) {
         return documentApi.getDocumentContent(path);
     }

--- a/src/main/java/no/digipost/api/client/document/DocumentApi.java
+++ b/src/main/java/no/digipost/api/client/document/DocumentApi.java
@@ -51,6 +51,12 @@ public interface DocumentApi {
      * @param partId Frivillig organisasjons-enhet, kan være {@code null}
      *
      */
+
+    /**
+     * Henter status på peppol melding.
+     */
+    DocumentStatus getPeppolStatus(SenderId senderId, UUID uuid);
+
     DocumentEvents getDocumentEvents(String organisation, String partId, ZonedDateTime from, ZonedDateTime to, int offset, int maxResults);
 
 }

--- a/src/main/java/no/digipost/api/client/internal/ApiServiceImpl.java
+++ b/src/main/java/no/digipost/api/client/internal/ApiServiceImpl.java
@@ -270,6 +270,11 @@ public class ApiServiceImpl implements MessageDeliveryApi, InboxApi, DocumentApi
     }
 
     @Override
+    public DocumentStatus getPeppolStatus(SenderId senderId, UUID uuid) {
+        return getDocumentStatus("documents/peppol/"+ senderId.stringValue() + "/" + uuid);
+    }
+
+    @Override
     public Recipients search(String searchString) {
         HttpGet httpGet = new HttpGet(digipostUrl.resolve(createEncodedURIPath(getEntryPoint().getSearchUri().getPath() + "/" + searchString)));
         return requestEntity(httpGet, Recipients.class);

--- a/src/main/java/no/digipost/api/client/representations/DeliveryStatus.java
+++ b/src/main/java/no/digipost/api/client/representations/DeliveryStatus.java
@@ -22,5 +22,6 @@ import javax.xml.bind.annotation.XmlType;
 @XmlEnum
 public enum DeliveryStatus {
     DELIVERED,
-    NOT_DELIVERED;
+    NOT_DELIVERED,
+    FAILED;
 }

--- a/src/main/resources/xsd/api_v7.xsd
+++ b/src/main/resources/xsd/api_v7.xsd
@@ -1013,6 +1013,7 @@
         <xsd:restriction base="xsd:string">
             <xsd:enumeration value="DELIVERED" />
             <xsd:enumeration value="NOT_DELIVERED" />
+            <xsd:enumeration value="FAILED" />
         </xsd:restriction>
     </xsd:simpleType>
 


### PR DESCRIPTION
Added support for retrieving peppol message status from Digipost. Need this functionality as a part of fallback solution when sending Peppol messages. 