### PR TITLE
add peppolfailedmetadata documenteventmetadata

### DIFF
--- a/src/main/java/no/digipost/api/client/representations/FailedPeppolMetadata.java
+++ b/src/main/java/no/digipost/api/client/representations/FailedPeppolMetadata.java
@@ -18,18 +18,22 @@ package no.digipost.api.client.representations;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "event-metadata")
-@XmlSeeAlso({
-        MoveFilesFromPublicSectorMetadata.class,
-        EmailNotificationFailedMetadata.class,
-        SmsNotificationFailedMetadata.class,
-        FailedPrintMetadata.class,
-        FailedPeppolMetadata.class,
-        PostmarkedMetadata.class
-})
-public abstract class EventMetadata {
+@XmlType(name = "failed-peppol-metadata")
+public class FailedPeppolMetadata extends EventMetadata {
+
+    @XmlAttribute(name = "error-code")
+	public final String errorCode;
+
+    public FailedPeppolMetadata() {
+        this(null);
+    }
+
+    public FailedPeppolMetadata(String errorCode) {
+		this.errorCode = errorCode;
+	}
+
 }

--- a/src/main/resources/xsd/api_v7.xsd
+++ b/src/main/resources/xsd/api_v7.xsd
@@ -1110,6 +1110,14 @@
         </xsd:complexContent>
     </xsd:complexType>
 
+    <xsd:complexType name="failed-peppol-metadata">
+        <xsd:complexContent>
+            <xsd:extension base="event-metadata">
+                <xsd:attribute name="error-code" type="xsd:string" use="required" />
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
     <xsd:complexType name="postmarked-metadata">
         <xsd:complexContent>
             <xsd:extension base="event-metadata">


### PR DESCRIPTION
legger til PeppolFailedMetadata dokument-event-metadata  (dette skulle vært gjort ifb. adding av dokumenteventypene for Peppol