### PR TITLE
let a broker fetch documentEvents on behalf of a techincal sender id

### DIFF
--- a/src/main/java/no/digipost/api/client/DigipostClient.java
+++ b/src/main/java/no/digipost/api/client/DigipostClient.java
@@ -151,11 +151,16 @@ public class DigipostClient {
     }
 
     public DocumentEvents getDocumentEvents(ZonedDateTime from, ZonedDateTime to, int offset, int maxResults) {
-        return getDocumentEvents(null, null, from, to, offset, maxResults);
+        return getDocumentEvents(null, from, to, offset, maxResults);
     }
 
+    public DocumentEvents getDocumentEvents(SenderId senderId, ZonedDateTime from, ZonedDateTime to, int offset, int maxResults) {
+        return documentApi.getDocumentEvents(null, null, senderId,  from, to, offset, maxResults);
+    }
+
+
     public DocumentEvents getDocumentEvents(String organisation, String partId, ZonedDateTime from, ZonedDateTime to, int offset, int maxResults) {
-        return documentApi.getDocumentEvents(organisation, partId, from, to, offset, maxResults);
+        return documentApi.getDocumentEvents(organisation, partId, null, from, to, offset, maxResults);
     }
 
     /**

--- a/src/main/java/no/digipost/api/client/document/DocumentApi.java
+++ b/src/main/java/no/digipost/api/client/document/DocumentApi.java
@@ -51,6 +51,6 @@ public interface DocumentApi {
      * @param partId Frivillig organisasjons-enhet, kan være {@code null}
      *
      */
-    DocumentEvents getDocumentEvents(String organisation, String partId, ZonedDateTime from, ZonedDateTime to, int offset, int maxResults);
+    DocumentEvents getDocumentEvents(String organisation, String partId, SenderId senderId, ZonedDateTime from, ZonedDateTime to, int offset, int maxResults);
 
 }

--- a/src/main/java/no/digipost/api/client/internal/ApiServiceImpl.java
+++ b/src/main/java/no/digipost/api/client/internal/ApiServiceImpl.java
@@ -226,7 +226,7 @@ public class ApiServiceImpl implements MessageDeliveryApi, InboxApi, DocumentApi
 
 
     @Override
-    public DocumentEvents getDocumentEvents(String organisation, String partId, ZonedDateTime from, ZonedDateTime to, int offset, int maxResults) {
+    public DocumentEvents getDocumentEvents(String organisation, String partId, SenderId senderId, ZonedDateTime from, ZonedDateTime to, int offset, int maxResults) {
         URIBuilder builder = new URIBuilder(digipostUrl.resolve(getEntryPoint().getDocumentEventsUri().getPath()))
                 .setParameter("from", DATE_TIME_FORMAT.format(from))
                 .setParameter("to", DATE_TIME_FORMAT.format(to))
@@ -238,6 +238,9 @@ public class ApiServiceImpl implements MessageDeliveryApi, InboxApi, DocumentApi
         }
         if (partId != null) {
             builder = builder.setParameter("part", partId);
+        }
+        if (senderId != null) {
+            builder = builder.setParameter("sender", senderId.stringValue());
         }
 
         try {


### PR DESCRIPTION
let a broker fetch documentEvents on behalf of a techincal sender id, as well as the already existing method of doing it via organisation number and part-id