### PR TITLE
Bump printability-validator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>printability-validator</artifactId>
-            <version>3.1</version>
+            <version>3.2</version>
         </dependency>
         <dependency>
             <groupId>no.digipost</groupId>


### PR DESCRIPTION
 Includes pdfbox v2.0.24.

```
--- maven-dependency-plugin:3.1.2:tree (default-cli) @ digipost-api-client-java ---
no.digipost:digipost-api-client-java:jar:14.1-SNAPSHOT
+- no.digipost:printability-validator:jar:3.2:compile
|  \- org.apache.pdfbox:pdfbox:jar:2.0.24:compile
|     \- org.apache.pdfbox:fontbox:jar:2.0.24:compile
```

Resolves #121