### PR TITLE
Disable dump of differing html on sanitation differences by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>digipost-html-validator</artifactId>
-            <version>1.0.5</version>
+            <version>disable-sanitized-html-in-validation-result-by-default-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>no.digipost</groupId>
@@ -540,5 +540,18 @@
         <url>scm:git:git@github.com:digipost/digipost-api-client-java</url>
         <tag>HEAD</tag>
     </scm>
+
+    <repositories>
+        <repository>
+            <id>oss.sonatype.org-snapshot</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
 </project>

--- a/src/main/java/no/digipost/api/client/DigipostClientConfig.java
+++ b/src/main/java/no/digipost/api/client/DigipostClientConfig.java
@@ -33,6 +33,7 @@ public final class DigipostClientConfig {
         private EventLogger eventLogger = EventLogger.NOOP_LOGGER;
         private Clock clock = Clock.systemDefaultZone();
         private boolean failOnHtmlDiff = false;
+        private boolean dumpHtmlPayload = false;
 
         private Builder() {
         }
@@ -56,6 +57,11 @@ public final class DigipostClientConfig {
             return this;
         }
 
+        public Builder dumpHtmlPayload(){
+            this.dumpHtmlPayload = true;
+            return this;
+        }
+
         public Builder eventLogger(EventLogger eventLogger) {
             this.eventLogger = eventLogger;
             return this;
@@ -67,7 +73,7 @@ public final class DigipostClientConfig {
         }
 
         public DigipostClientConfig build() {
-            return new DigipostClientConfig(digipostApiUri, printKeyCacheTimeToLive, eventLogger, clock, failOnHtmlDiff);
+            return new DigipostClientConfig(digipostApiUri, printKeyCacheTimeToLive, eventLogger, clock, failOnHtmlDiff, dumpHtmlPayload);
         }
     }
 
@@ -80,13 +86,16 @@ public final class DigipostClientConfig {
     public final EventLogger eventLogger;
     public final Clock clock;
     public final boolean failOnHtmlDiff;
+    public final boolean dumpHtmlPayload;
 
-    private DigipostClientConfig(URI digipostApiUri, Duration printKeyCacheTimeToLive, EventLogger eventLogger, Clock clock, boolean failOnHtmlDiff) {
-        this.digipostApiUri = requireNonNull(digipostApiUri, "digipostApiUri cat not be null");
+    private DigipostClientConfig(URI digipostApiUri, Duration printKeyCacheTimeToLive, EventLogger eventLogger,
+            Clock clock, boolean failOnHtmlDiff, boolean dumpHtmlPayload) {
+        this.digipostApiUri = requireNonNull(digipostApiUri, "digipostApiUri can not be null");
         this.printKeyCacheTimeToLive = requireNonNull(printKeyCacheTimeToLive, "printKeyCacheTimeToLive can not be null");
         this.eventLogger = requireNonNull(eventLogger, "eventLogger can not be null");
         this.clock = clock;
         this.failOnHtmlDiff = failOnHtmlDiff;
+        this.dumpHtmlPayload = dumpHtmlPayload;
     }
 
 }

--- a/src/main/java/no/digipost/api/client/internal/delivery/DocumentsPreparer.java
+++ b/src/main/java/no/digipost/api/client/internal/delivery/DocumentsPreparer.java
@@ -86,7 +86,7 @@ class DocumentsPreparer {
     void validateHtml(Document document, byte[] content, DigipostClientConfig config) {
         HtmlValidationResult htmlValidation = HTML_EVERYTHING_OK;
         if (document.is(HTML) || document.is(HTM)) {
-            htmlValidation = htmlValidator.valider(content);
+            htmlValidation = htmlValidator.valider(content, config.dumpHtmlPayload);
         }
 
         if (!htmlValidation.okForWeb) {


### PR DESCRIPTION
(DigipostClientConfig.dumpHtmlPayload) New setting, to revert the new
default behaviour.
(DocumentsPreparer.validateHtml) Pass the new setting, dumpHtmlPayload,
to the HtmlValidator.
(DocumentsPreparerTest) Add a test for the case of enabled sanitaized
html dump. Refactor reused test code into new method.
(pom.xml) Temporarily, use Sonatype snapshot of digipost-html-validator.