### PR TITLE
Update xsd v8

### DIFF
--- a/src/main/java/no/digipost/api/client/representations/EmailDeliveredMetadata.java
+++ b/src/main/java/no/digipost/api/client/representations/EmailDeliveredMetadata.java
@@ -1,0 +1,20 @@
+package no.digipost.api.client.representations;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "email-delivered-metadata")
+public class EmailDeliveredMetadata extends EventMetadata {
+
+    @XmlAttribute(name = "email-address")
+    public final String emailAddress;
+
+    public EmailDeliveredMetadata() { this(null); }
+
+    public EmailDeliveredMetadata(String emailAddress) {
+        this.emailAddress = emailAddress;
+    }
+}

--- a/src/main/java/no/digipost/api/client/representations/EmailDeliveredMetadata.java
+++ b/src/main/java/no/digipost/api/client/representations/EmailDeliveredMetadata.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package no.digipost.api.client.representations;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/src/main/java/no/digipost/api/client/representations/EventMetadata.java
+++ b/src/main/java/no/digipost/api/client/representations/EventMetadata.java
@@ -25,6 +25,7 @@ import javax.xml.bind.annotation.XmlType;
 @XmlType(name = "event-metadata")
 @XmlSeeAlso({
         MoveFilesFromPublicSectorMetadata.class,
+        EmailDeliveredMetadata.class,
         EmailNotificationFailedMetadata.class,
         SmsNotificationFailedMetadata.class,
         FailedPrintMetadata.class,

--- a/src/main/resources/xsd/api_v8.xsd
+++ b/src/main/resources/xsd/api_v8.xsd
@@ -1034,14 +1034,22 @@
         </xsd:complexContent>
     </xsd:complexType>
 
-    <xsd:complexType name="email-notification-failed-metadata">
-        <xsd:complexContent>
-            <xsd:extension base="event-metadata">
-                <xsd:attribute name="email-address" type="xsd:string" use="required" />
-                <xsd:attribute name="error-code" type="xsd:string" use="required" />
-            </xsd:extension>
-        </xsd:complexContent>
-    </xsd:complexType>
+	<xsd:complexType name="email-delivered-metadata">
+		<xsd:complexContent>
+			<xsd:extension base="event-metadata">
+				<xsd:attribute name="email-address" type="xsd:string" use="required" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="email-notification-failed-metadata">
+		<xsd:complexContent>
+			<xsd:extension base="event-metadata">
+				<xsd:attribute name="email-address" type="xsd:string" use="required" />
+				<xsd:attribute name="error-code" type="xsd:string" use="required" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
 
     <xsd:complexType name="sms-notification-failed-metadata">
         <xsd:complexContent>
@@ -1281,7 +1289,7 @@
 	</xsd:complexType>
 
 	<xsd:element name="batch" type="batch" />
-	
+
 	<xsd:complexType name="batch">
 		<xsd:sequence>
 			<xsd:element name="uuid" type="uuid" minOccurs="1" maxOccurs="1" nillable="false" />
@@ -1333,5 +1341,5 @@
             </xsd:enumeration>
         </xsd:restriction>
     </xsd:simpleType>
-	
+
 </xsd:schema>

--- a/src/test/java/no/digipost/api/client/representations/XsdValidationTest.java
+++ b/src/test/java/no/digipost/api/client/representations/XsdValidationTest.java
@@ -35,6 +35,7 @@ import static no.digipost.api.client.representations.AuthenticationLevel.IDPORTE
 import static no.digipost.api.client.representations.AuthenticationLevel.PASSWORD;
 import static no.digipost.api.client.representations.AuthenticationLevel.TWO_FACTOR;
 import static no.digipost.api.client.representations.Channel.DIGIPOST;
+import static no.digipost.api.client.representations.DocumentEventType.EMAIL_MESSAGE_SENT;
 import static no.digipost.api.client.representations.DocumentEventType.EMAIL_NOTIFICATION_FAILED;
 import static no.digipost.api.client.representations.DocumentEventType.MOVE_FILES_FROM_PUBLIC_SECTOR;
 import static no.digipost.api.client.representations.DocumentEventType.OPENED;
@@ -189,6 +190,11 @@ public class XsdValidationTest {
         ZonedDateTime now = ZonedDateTime.now();
         DocumentEvent openedEvent = new DocumentEvent(randomUUID(), OPENED, now, now);
 
+        DocumentEvent emailDeliveredEvent = new DocumentEvent(randomUUID(), EMAIL_MESSAGE_SENT, now, now, null);
+
+        DocumentEvent emailDeliveredEventWithMetadata = new DocumentEvent(randomUUID(), EMAIL_MESSAGE_SENT, now, now,
+                new EmailDeliveredMetadata("example@test.com"));
+
         DocumentEvent failedEmailNotificationEvent = new DocumentEvent(randomUUID(), EMAIL_NOTIFICATION_FAILED, now, now,
                 new EmailNotificationFailedMetadata("emailAddress", "ERROR_CODE"));
 
@@ -208,8 +214,9 @@ public class XsdValidationTest {
 
         DocumentEvent shreddedEvent = new DocumentEvent(randomUUID(), SHREDDED, now, now);
 
-        DocumentEvents documentEvents = new DocumentEvents(asList(openedEvent, failedEmailNotificationEvent,
-                failedSmsNotificationEvent, printFailedEvent, movedFilesEvent, postmarkedEvent, shreddedEvent));
+        DocumentEvents documentEvents = new DocumentEvents(asList(openedEvent, emailDeliveredEvent,
+                emailDeliveredEventWithMetadata, failedEmailNotificationEvent, failedSmsNotificationEvent,
+                printFailedEvent, movedFilesEvent, postmarkedEvent, shreddedEvent));
         marshallValidateAndUnmarshall(documentEvents);
     }
 


### PR DESCRIPTION
Add EmailDeliveredMetadata-type from updated xsd v8. 

DocumentEvents of type EMAIL_MESSAGE_SENT may include this metadata, containing email address.