### PR TITLE
Add functionality to use archve document attributes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>digipost-data-types</artifactId>
-            <version>0.35</version>
+            <version>0.36</version>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>

--- a/src/main/java/no/digipost/api/client/DigipostClient.java
+++ b/src/main/java/no/digipost/api/client/DigipostClient.java
@@ -236,14 +236,11 @@ public class DigipostClient {
     /**
      * An Archive has an optional URL to fetch documents paged 100 at a time.
      * Eg.: `archive.getNextDocuments()`
-     *
-     * This Optional URI cat be put into this method to fetch that page of documents. We supply this fuctionality
-     * so that senders can use it to get an idea of the content of an archive. However it's use is strongly
-     * discouraged because it leads to the idea that an archive can be itereated. We expect an archive to possibly
-     * reach many million rows so the iteration will possibly give huge loads. On the other hand being able to
-     * dump all data is a nessary feature of any archive.
-     *
-     * Please use fetch document by UUID or referenceID instead to create functionality on top of the archive.
+     * 
+     * It can also be used by the url supplied by
+     * `archive.getNextDocumentsWithAttributes(Map.of("MyKey", "MyVal")`
+     * This will return paged results that matches the attributes supplied. 
+     * More attributes narrows the search (S1 AND S2).
      *
      * @param uri URI supplied by the api with Relation NEXT_DOCUMENTS
      * @return An archive with documents.
@@ -330,8 +327,11 @@ public class DigipostClient {
         return archiveApi.getArchiveDocumentContentStream(uri);
     }
 
-    public void deleteArchiveDocument(ArchiveDocument archiveDocument) {
+    public void deleteArchiveDocument(URI archiveDocument) {
         archiveApi.deleteArchiveDocumentByUUID(archiveDocument);
+    }
+    public ArchiveDocument updateArchiveDocument(ArchiveDocument archiveDocument, URI uri) {
+        return archiveApi.saveArchiveDocument(archiveDocument, uri);
     }
 
     public Batch createBatch(UUID batchUUID) {
@@ -345,7 +345,7 @@ public class DigipostClient {
     public Batch completeBatch(Batch batch) {
         return batchApi.completeBatch(batch);
     }
-    
+
     public void cancelBatch(Batch batch) {
         batchApi.cancelBatch(batch);
     }

--- a/src/main/java/no/digipost/api/client/archive/ArchiveApi.java
+++ b/src/main/java/no/digipost/api/client/archive/ArchiveApi.java
@@ -38,9 +38,11 @@ public interface ArchiveApi {
 
     Archive getArchiveDocumentByUUID(SenderId senderId, UUID uuid);
 
-    void deleteArchiveDocumentByUUID(ArchiveDocument archiveDocument);
+    void deleteArchiveDocumentByUUID(URI deleteArchiveDocumentUri);
 
     Archive addUniqueUUIDToArchiveDocument(SenderId senderId, UUID uuid, UUID newuuid);
+
+    ArchiveDocument saveArchiveDocument(ArchiveDocument archiveDocument, URI uri);
 
     public static interface ArchivingDocuments {
 

--- a/src/main/java/no/digipost/api/client/internal/ApiServiceImpl.java
+++ b/src/main/java/no/digipost/api/client/internal/ApiServiceImpl.java
@@ -70,6 +70,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ByteArrayEntity;
@@ -363,11 +364,9 @@ public class ApiServiceImpl implements MessageDeliveryApi, InboxApi, DocumentApi
     }
 
     @Override
-    public void deleteArchiveDocumentByUUID(ArchiveDocument archiveDocument) {
-        final URI uri = archiveDocument.deleteArchiveDocumentUri();
-        send(new HttpDelete(uri));
+    public void deleteArchiveDocumentByUUID(URI deleteArchiveDocumentUri) {
+        send(new HttpDelete(digipostUrl.resolve(deleteArchiveDocumentUri.getPath())));
     }
-
 
     @Override
     public Archive addUniqueUUIDToArchiveDocument(SenderId senderId, UUID uuid, UUID newuuid) {
@@ -391,6 +390,17 @@ public class ApiServiceImpl implements MessageDeliveryApi, InboxApi, DocumentApi
         } catch (IOException e) {
             throw new DigipostClientException(ErrorCode.GENERAL_ERROR, e);
         }
+    }
+
+    @Override
+    public ArchiveDocument saveArchiveDocument(ArchiveDocument archiveDocument, URI uri) {
+        final HttpPut httpPut = new HttpPut(digipostUrl.resolve(uri.getPath()));
+        httpPut.setHeader(Content_Type_DIGIPOST_MEDIA_TYPE_V8);
+        ByteArrayOutputStream bao = new ByteArrayOutputStream();
+        marshal(jaxbContext, archiveDocument, bao);
+        httpPut.setEntity(new ByteArrayEntity(bao.toByteArray()));
+        
+        return requestEntity(httpPut, ArchiveDocument.class);
     }
 
     @Override

--- a/src/main/java/no/digipost/api/client/representations/Relation.java
+++ b/src/main/java/no/digipost/api/client/representations/Relation.java
@@ -17,6 +17,7 @@ package no.digipost.api.client.representations;
 
 public enum Relation {
     SELF,
+    SELF_UPDATE,
     SELF_DELETE,
     ADD_CONTENT,
     SEND,

--- a/src/main/java/no/digipost/api/client/representations/archive/ArchiveDocument.java
+++ b/src/main/java/no/digipost/api/client/representations/archive/ArchiveDocument.java
@@ -31,14 +31,18 @@ import java.net.URI;
 import java.time.Clock;
 import java.time.Period;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static no.digipost.api.client.representations.Relation.ADD_UNIQUE_UUID;
-import static no.digipost.api.client.representations.Relation.DELETE_ARCHIVE_DOCUMENT_BY_UUID;
 import static no.digipost.api.client.representations.Relation.GET_ARCHIVE_DOCUMENT_BY_UUID;
 import static no.digipost.api.client.representations.Relation.GET_ARCHIVE_DOCUMENT_CONTENT;
 import static no.digipost.api.client.representations.Relation.GET_ARCHIVE_DOCUMENT_CONTENT_STREAM;
+import static no.digipost.api.client.representations.Relation.SELF_DELETE;
+import static no.digipost.api.client.representations.Relation.SELF_UPDATE;
 
 
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -49,6 +53,7 @@ import static no.digipost.api.client.representations.Relation.GET_ARCHIVE_DOCUME
         "referenceid",
         "contentType",
         "contentHash",
+        "attributes",
         "archivedTime",
         "deletionTime",
         "links"
@@ -68,6 +73,10 @@ public class ArchiveDocument extends Representation {
     protected String contentType;
     @XmlElement(name = "content-hash", nillable = false)
     protected ContentHash contentHash;
+
+    @XmlElement(nillable = false)
+    protected List<ArchiveDocumentAttribute> attributes;
+
     @XmlElement(name = "archived-time", type = String.class, nillable = false)
     @XmlJavaTypeAdapter(DateTimeXmlAdapter.class)
     @XmlSchemaType(name = "dateTime")
@@ -76,7 +85,6 @@ public class ArchiveDocument extends Representation {
     @XmlJavaTypeAdapter(DateTimeXmlAdapter.class)
     @XmlSchemaType(name = "dateTime")
     protected ZonedDateTime deletionTime;
-
     public ArchiveDocument() {
         this(null, null, null, null);
     }
@@ -86,23 +94,40 @@ public class ArchiveDocument extends Representation {
         this.fileName = fileName;
         this.fileType = fileType;
         this.contentType = contentType;
+        this.attributes = new ArrayList<>();
     }
 
-    public ArchiveDocument withReferenceId(final String referenceid){
+    public ArchiveDocument withAttribute(String key, String value) {
+        // check duplicate and overwrite value
+        final Optional<ArchiveDocumentAttribute> first = this.attributes.stream().filter(s -> s.key.equals(key)).findFirst();
+        if (first.isPresent()) {
+            first.get().value = value;
+        } else {
+            this.attributes.add(new ArchiveDocumentAttribute(key, value));
+        }
+        return this;
+    }
+
+    public ArchiveDocument withAttributes(Map<String, String> attributes) {
+        attributes.forEach(this::withAttribute);
+        return this;
+    }
+
+    public ArchiveDocument withReferenceId(final String referenceid) {
         this.referenceid = referenceid;
         return this;
     }
-    
-    public ArchiveDocument withDeletionTime(final ZonedDateTime deletionTime){
+
+    public ArchiveDocument withDeletionTime(final ZonedDateTime deletionTime) {
         this.deletionTime = deletionTime;
         return this;
     }
-    
-    public ArchiveDocument withDeleteAfter(Period duration, Clock clock){
+
+    public ArchiveDocument withDeleteAfter(Period duration, Clock clock) {
         this.deletionTime = ZonedDateTime.now(clock).plus(duration);
         return this;
     }
-    
+
     public UUID getUuid() {
         return uuid;
     }
@@ -131,6 +156,10 @@ public class ArchiveDocument extends Representation {
         this.contentHash = value;
     }
 
+    public List<ArchiveDocumentAttribute> getAttributes() {
+        return attributes;
+    }
+
     public ZonedDateTime getArchivedTime() {
         return archivedTime;
     }
@@ -152,16 +181,20 @@ public class ArchiveDocument extends Representation {
         return getLinkByRelationName(GET_ARCHIVE_DOCUMENT_CONTENT).getUri();
     }
 
+    public URI getUpdate() {
+        return getLinkByRelationName(SELF_UPDATE).getUri();
+    }
+
+    public URI getDelete() {
+        return getLinkByRelationName(SELF_DELETE).getUri();
+    }
+
     public URI getAddUniqueUUID() {
         return getLinkByRelationName(ADD_UNIQUE_UUID).getUri();
     }
 
     public URI getDocumentContentStream() {
         return getLinkByRelationName(GET_ARCHIVE_DOCUMENT_CONTENT_STREAM).getUri();
-    }
-
-    public URI deleteArchiveDocumentUri() {
-        return getLinkByRelationName(DELETE_ARCHIVE_DOCUMENT_BY_UUID).getUri();
     }
 
     @Override
@@ -173,6 +206,7 @@ public class ArchiveDocument extends Representation {
                 ", referenceid='" + referenceid + '\'' +
                 ", contentType='" + contentType + '\'' +
                 ", contentHash=" + contentHash.getHashAlgorithm() + ":" + contentHash.getHash() +
+                ", attributes=" + attributes +
                 ", archivedTime=" + archivedTime +
                 ", deletionTime=" + deletionTime +
                 '}';

--- a/src/main/java/no/digipost/api/client/representations/archive/ArchiveDocumentAttribute.java
+++ b/src/main/java/no/digipost/api/client/representations/archive/ArchiveDocumentAttribute.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.representations.archive;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "archive-document-attribute", propOrder = {
+        "key",
+        "value"
+})
+@XmlRootElement(name = "archive-document-attribute")
+public class ArchiveDocumentAttribute {
+
+    @XmlElement(name = "key", required = true)
+    protected String key;
+    @XmlElement(name = "value", required = true)
+    protected String value;
+
+    public ArchiveDocumentAttribute() {
+        super();
+    }
+
+    public ArchiveDocumentAttribute(final String key, final String uri) {
+        this.key = key;
+        this.value = uri;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "{key='" + key + "', value='" + value + "'}";
+    }
+}

--- a/src/main/java/no/digipost/api/client/representations/archive/Archives.java
+++ b/src/main/java/no/digipost/api/client/representations/archive/Archives.java
@@ -25,6 +25,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "archives", propOrder = {
@@ -57,5 +58,7 @@ public class Archives extends Representation {
         }
         return this.archives;
     }
-
+    public Optional<Archive> findDefault(){
+        return this.getArchives().stream().filter(a -> a.name == null).findAny();
+    }
 }

--- a/src/main/resources/xsd/api_v8.xsd
+++ b/src/main/resources/xsd/api_v8.xsd
@@ -1273,6 +1273,7 @@
 			</xsd:element>
 			<xsd:element name="content-type" type="xsd:string" minOccurs="0" maxOccurs="1"/>
 			<xsd:element name="content-hash" type="content-hash" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="attributes" type="archive-document-attribute" minOccurs="0" maxOccurs="15"/>
 			<xsd:element name="archived-time" type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
 			<xsd:element name="deletion-time" type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
 			<xsd:element name="link" type="link" minOccurs="0" maxOccurs="unbounded"/>
@@ -1288,8 +1289,29 @@
 		</xsd:sequence>
 	</xsd:complexType>
 
+	<xsd:element name="archive-document-attribute" type="archive-document-attribute" />
+	
+	<xsd:complexType name="archive-document-attribute">
+		<xsd:sequence>
+			<xsd:element name="key" nillable="false" minOccurs="1" maxOccurs="1">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:maxLength value="20"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:element>
+			<xsd:element name="value" nillable="false" minOccurs="1" maxOccurs="1">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:maxLength value="100"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	
 	<xsd:element name="batch" type="batch" />
-
+	
 	<xsd:complexType name="batch">
 		<xsd:sequence>
 			<xsd:element name="uuid" type="uuid" minOccurs="1" maxOccurs="1" nillable="false" />

--- a/src/test/java/no/digipost/api/client/eksempelkode/ArkiverDokumenterEksempel.java
+++ b/src/test/java/no/digipost/api/client/eksempelkode/ArkiverDokumenterEksempel.java
@@ -58,14 +58,16 @@ public class ArkiverDokumenterEksempel {
                 , "faktura_123123.pdf"
                 , "pdf"
                 , "application/pdf"
-        ).withReferenceId("234234235234235");
-        
+        ).withReferenceId("234234235234235").withAttribute("FNR", "123123");
+
         final ArchiveDocument vedlegg = new ArchiveDocument(
                 UUID.randomUUID()
                 , "vedlegg_123123.pdf"
                 , "pdf"
                 , "application/pdf"
-        ).withReferenceId("234234235234235").withDeletionTime(ZonedDateTime.now().plusMonths(6));
+        ).withReferenceId("234234235234235")
+                .withDeletionTime(ZonedDateTime.now().plusMonths(6))
+                .withAttribute("FNR", "123123");
 
         // 4. Vi oppretter arkivmeldingen med dokumentene
         Archive archive = Archive.defaultArchive()

--- a/src/test/java/no/digipost/api/client/representations/archive/ArchiveDocumentTest.java
+++ b/src/test/java/no/digipost/api/client/representations/archive/ArchiveDocumentTest.java
@@ -15,13 +15,16 @@
  */
 package no.digipost.api.client.representations.archive;
 
-import co.unruly.matchers.Java8Matchers;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.UUID;
 
+import static co.unruly.matchers.Java8Matchers.where;
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 class ArchiveDocumentTest {
@@ -35,7 +38,7 @@ class ArchiveDocumentTest {
                 , "application/pdf"
         );
 
-        assertThat(document, Java8Matchers.where(ArchiveDocument::getUuid, equalTo(UUID.fromString("aaf94188-49ba-3e02-ad14-4cdd83b1814b"))));
+        assertThat(document, where(ArchiveDocument::getUuid, equalTo(UUID.fromString("aaf94188-49ba-3e02-ad14-4cdd83b1814b"))));
     }
 
     @Test
@@ -47,6 +50,22 @@ class ArchiveDocumentTest {
                 , "application/pdf"
         ).withReferenceId("ref:1213").withDeletionTime(ZonedDateTime.now().plusMonths(6));
 
-        assertThat(document, Java8Matchers.where(ArchiveDocument::getReferenceid, equalTo("ref:1213")));
+        assertThat(document, where(ArchiveDocument::getReferenceid, equalTo("ref:1213")));
+    }
+
+    @Test
+    void add_attributes_to_a_archive_document() {
+        final ArchiveDocument document = new ArchiveDocument(
+                UUID.randomUUID()
+                , "minfil.pdf"
+                , "pdf"
+                , "application/pdf"
+        ).withAttributes(new HashMap<String, String>(){{put("ID", "1234");}});
+        assertThat(document, where(ArchiveDocument::getAttributes, contains(
+                allOf(
+                        where(ArchiveDocumentAttribute::getKey, equalTo("ID")),
+                        where(ArchiveDocumentAttribute::getKey, equalTo("ID"))
+                )
+        )));
     }
 }


### PR DESCRIPTION
You can now add, update and query archive documents attributes to build better processes archive documents.

![image](https://user-images.githubusercontent.com/383121/197515344-1a3c64d9-7d55-4971-b8fa-e834d00d620f.png)

![image](https://user-images.githubusercontent.com/383121/197508956-e441eeff-77f3-4866-8304-cb868a1ff7cd.png)

