### PR TITLE
Add and remove tags for user accounts

### DIFF
--- a/src/main/java/no/digipost/api/client/DigipostClient.java
+++ b/src/main/java/no/digipost/api/client/DigipostClient.java
@@ -37,6 +37,7 @@ import no.digipost.api.client.representations.Link;
 import no.digipost.api.client.representations.Message;
 import no.digipost.api.client.representations.Recipients;
 import no.digipost.api.client.representations.accounts.UserAccount;
+import no.digipost.api.client.representations.accounts.Tag;
 import no.digipost.api.client.representations.accounts.UserInformation;
 import no.digipost.api.client.representations.archive.Archive;
 import no.digipost.api.client.representations.archive.ArchiveDocument;
@@ -48,6 +49,7 @@ import no.digipost.api.client.representations.inbox.InboxDocument;
 import no.digipost.api.client.representations.sender.SenderInformation;
 import no.digipost.api.client.security.CryptoUtil;
 import no.digipost.api.client.security.Signer;
+import no.digipost.api.client.tag.TagApi;
 import no.digipost.api.client.util.JAXBContextUtils;
 import no.digipost.http.client3.DigipostHttpClientFactory;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -86,6 +88,7 @@ public class DigipostClient {
     private final DocumentApi documentApi;
     private final ArchiveApi archiveApi;
     private final BatchApi batchApi;
+    private final TagApi tagApi;
 
 
     public DigipostClient(DigipostClientConfig config, BrokerId brokerId, Signer signer) {
@@ -97,15 +100,16 @@ public class DigipostClient {
     }
 
     private DigipostClient(DigipostClientConfig config, ApiServiceImpl apiService) {
-        this(config, apiService, apiService, apiService, apiService, apiService);
+        this(config, apiService, apiService, apiService, apiService, apiService, apiService);
     }
 
-    public DigipostClient(DigipostClientConfig config, MessageDeliveryApi apiService, InboxApi inboxApiService, DocumentApi documentApi, ArchiveApi archiveApi, BatchApi batchApi) {
+    public DigipostClient(DigipostClientConfig config, MessageDeliveryApi apiService, InboxApi inboxApiService, DocumentApi documentApi, ArchiveApi archiveApi, BatchApi batchApi, TagApi tagApi) {
         this.messageApi = apiService;
         this.inboxApiService = inboxApiService;
         this.documentApi = documentApi;
         this.archiveApi = archiveApi;
         this.batchApi = batchApi;
+        this.tagApi = tagApi;
 
         this.messageSender = new MessageDeliverer(config, apiService);
         this.archiveSender = new ArchiveDeliverer(config, archiveApi);
@@ -293,6 +297,14 @@ public class DigipostClient {
 
     public UserAccount createOrActivateUserAccount(SenderId senderId, UserInformation user) {
         return messageApi.createOrActivateUserAccount(senderId, user);
+    }
+
+    public void addTag(Tag tag) {
+        tagApi.addTag(tag);
+    }
+
+    public void removeTag(Tag tag) {
+        tagApi.removeTag(tag);
     }
 
     public ArchiveApi.ArchivingDocuments archiveDocuments(final Archive archive) {

--- a/src/main/java/no/digipost/api/client/representations/EntryPoint.java
+++ b/src/main/java/no/digipost/api/client/representations/EntryPoint.java
@@ -104,6 +104,12 @@ public class EntryPoint extends Representation {
         return getLinkByRelationName(GET_SENDER_INFORMATION).getUri();
     }
 
+    public URI getAddTagUri() { return getLinkByRelationName(ADD_TAG).getUri(); }
+
+    public URI getRemoveTagUri() { return getLinkByRelationName(REMOVE_TAG).getUri(); }
+
+    public URI getCreateOrActivateUserAccountUri() { return getLinkByRelationName(CREATE_OR_ACTIVATE_USER_ACCOUNT).getUri(); }
+
     public String getCertificate() {
         return certificate;
     }

--- a/src/main/java/no/digipost/api/client/representations/Relation.java
+++ b/src/main/java/no/digipost/api/client/representations/Relation.java
@@ -48,4 +48,8 @@ public enum Relation {
     CREATE_BATCH,
 	GET_BATCH,
 	COMPLETE_BATCH,
+    CREATE_OR_ACTIVATE_USER_ACCOUNT,
+    ADD_TAG,
+    REMOVE_TAG,
+
 }

--- a/src/main/java/no/digipost/api/client/representations/accounts/PublicMailboxTag.java
+++ b/src/main/java/no/digipost/api/client/representations/accounts/PublicMailboxTag.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.representations.accounts;
+
+import no.digipost.api.client.representations.PersonalIdentificationNumber;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "public-mailbox-tag", propOrder = { "personalIdentificationNumber" })
+@XmlRootElement(name = "public-mailbox-tag")
+public class PublicMailboxTag {
+
+    @XmlElement(name = "personal-identification-number", nillable = false)
+    protected String personalIdentificationNumber;
+
+    public PublicMailboxTag() {
+    }
+
+    public PublicMailboxTag(final PersonalIdentificationNumber personalIdentificationNumber) {
+        this.personalIdentificationNumber = personalIdentificationNumber.asString();
+    }
+
+    public String getPersonalIdentificationNumber() {
+        return personalIdentificationNumber;
+    }
+}

--- a/src/main/java/no/digipost/api/client/representations/accounts/Tag.java
+++ b/src/main/java/no/digipost/api/client/representations/accounts/Tag.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.representations.accounts;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "tag", propOrder = { "publicMailboxTag" })
+@XmlRootElement(name = "tag")
+public class Tag {
+
+    @XmlElement(name = "public-mailbox-tag")
+    protected PublicMailboxTag publicMailboxTag;
+
+    public Tag() {
+    }
+
+    public Tag(PublicMailboxTag publicMailboxTag) {
+        this.publicMailboxTag = publicMailboxTag;
+    }
+
+    public PublicMailboxTag getPublicMailboxTag() {
+        return publicMailboxTag;
+    }
+}

--- a/src/main/java/no/digipost/api/client/tag/TagApi.java
+++ b/src/main/java/no/digipost/api/client/tag/TagApi.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.tag;
+
+import no.digipost.api.client.representations.accounts.Tag;
+
+/**
+ * Klasser som implementerer dette interfacet håndterer det å sette og fjerne
+ * såkalte tags fra brukerkontoer via Digipost sitt API. Tags indikerer egenskaper
+ * ved en konto, som f.eks om de har aktivert mottak av offentlig post eller ikke.
+ * For å administrere slike tags trengs det nødvendige tilganger til Digipost sitt API
+
+ */
+public interface TagApi {
+
+    void addTag(Tag tag);
+
+    void removeTag(Tag tag);
+
+}

--- a/src/main/java/no/digipost/api/client/util/JAXBContextUtils.java
+++ b/src/main/java/no/digipost/api/client/util/JAXBContextUtils.java
@@ -29,7 +29,9 @@ import no.digipost.api.client.representations.IdentificationResultWithEncryption
 import no.digipost.api.client.representations.Message;
 import no.digipost.api.client.representations.MessageDelivery;
 import no.digipost.api.client.representations.Recipients;
+import no.digipost.api.client.representations.accounts.PublicMailboxTag;
 import no.digipost.api.client.representations.accounts.UserAccount;
+import no.digipost.api.client.representations.accounts.Tag;
 import no.digipost.api.client.representations.accounts.UserInformation;
 import no.digipost.api.client.representations.archive.Archive;
 import no.digipost.api.client.representations.archive.ArchiveDocument;
@@ -48,7 +50,8 @@ public class JAXBContextUtils {
             EntryPoint.class, ErrorMessage.class, Identification.class, IdentificationResult.class, Message.class, Recipients.class,
             Autocomplete.class, DocumentEvents.class, DocumentStatus.class, MessageDelivery.class, EncryptionKey.class,
             IdentificationResultWithEncryptionKey.class, SenderInformation.class, UserInformation.class, UserAccount.class,
-            AdditionalData.class, EncryptionCertificate.class, Archives.class, Archive.class, ArchiveDocument.class
+            AdditionalData.class, EncryptionCertificate.class, Archives.class, Archive.class, ArchiveDocument.class,
+            Tag.class, PublicMailboxTag.class
     );
 
     private static JAXBContext initContext(Class<?>... clazz) {

--- a/src/main/resources/xsd/api_v8.xsd
+++ b/src/main/resources/xsd/api_v8.xsd
@@ -1364,4 +1364,39 @@
         </xsd:restriction>
     </xsd:simpleType>
 
+    <xsd:element name="tag" type="tag" />
+
+    <xsd:complexType name="tag">
+        <xsd:sequence>
+            <xsd:choice>
+                <xsd:element name="public-mailbox-tag" type="public-mailbox-tag">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            A tag which indicates that the corresponding account
+                            for the provided personal-identification-number should
+                            receive public mail through Digipost
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="public-mailbox-tag">
+        <xsd:sequence>
+            <xsd:element name="personal-identification-number" minOccurs="0" maxOccurs="1" nillable="false">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Fødselsnummer.
+                    </xsd:documentation>
+                </xsd:annotation>
+                <xsd:simpleType>
+                    <xsd:restriction base="xsd:string">
+                        <xsd:length value="11" />
+                    </xsd:restriction>
+                </xsd:simpleType>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
 </xsd:schema>

--- a/src/main/resources/xsd/api_v8.xsd
+++ b/src/main/resources/xsd/api_v8.xsd
@@ -1384,7 +1384,7 @@
 
     <xsd:complexType name="public-mailbox-tag">
         <xsd:sequence>
-            <xsd:element name="personal-identification-number" minOccurs="0" maxOccurs="1" nillable="false">
+            <xsd:element name="personal-identification-number" minOccurs="1" maxOccurs="1" nillable="false">
                 <xsd:annotation>
                     <xsd:documentation>
                         Fødselsnummer.

--- a/src/test/java/no/digipost/api/client/eksempelkode/AddTagEksempel.java
+++ b/src/test/java/no/digipost/api/client/eksempelkode/AddTagEksempel.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.eksempelkode;
+
+import no.digipost.api.client.BrokerId;
+import no.digipost.api.client.DigipostClient;
+import no.digipost.api.client.DigipostClientConfig;
+import no.digipost.api.client.representations.PersonalIdentificationNumber;
+import no.digipost.api.client.representations.accounts.PublicMailboxTag;
+import no.digipost.api.client.representations.accounts.Tag;
+import no.digipost.api.client.security.Signer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class AddTagEksempel {
+    // Din virksomhets Digipost-kontoid
+    private static final BrokerId AVSENDERS_KONTOID = BrokerId.of(10987);
+
+    // Passordet sertifikatfilen er beskyttet med
+    private static final String SERTIFIKAT_PASSORD = "SertifikatPassord123";
+
+    public static void main(final String[] args) throws IOException {
+
+        // 1. Vi lager en Signer ved å lese inn sertifikatet du har knyttet til
+        // din Digipost-konto (i .p12-formatet)
+        Signer signer;
+        try (InputStream sertifikatInputStream = lesInnSertifikat()) {
+            signer = Signer.usingKeyFromPKCS12KeyStore(sertifikatInputStream, SERTIFIKAT_PASSORD);
+        }
+
+        // 2. Vi oppretter en DigipostClient
+        DigipostClient client = new DigipostClient(DigipostClientConfig.newConfiguration().build(), AVSENDERS_KONTOID, signer);
+
+        // 3. Vi oppretter et fødselsnummerobjekt
+        PersonalIdentificationNumber pin = new PersonalIdentificationNumber("26079833787");
+
+        // 4. Vi oppretter en PublicMailboxTag
+        PublicMailboxTag publicMailboxTag = new PublicMailboxTag(pin);
+
+        // 5. Vi oppretter en Tag
+        Tag tag = new Tag(publicMailboxTag);
+
+        // 6. Vi lar klientbiblioteket sende requesten
+        client.addTag(tag);
+    }
+
+    private static InputStream lesInnSertifikat() {
+        try {
+            // Leser inn sertifikatet
+            return new FileInputStream(new File("/path/til/sertifikatfil.p12"));
+        } catch (FileNotFoundException e) {
+            // Håndter at sertifikatet ikke kunne leses!
+            throw new RuntimeException("Kunne ikke lese sertifikatfil: " + e.getMessage(), e);
+        }
+    }
+
+}


### PR DESCRIPTION
In the future, we want to expand this so that senders can manage various settings for their customers. For now, it only supports PublicMailboxTag, which is used to indicate whether a user should receive public mail or not, and is only available for Digdir in the context of managing public mailboxes.