### PR TITLE
Method to get list of tags for user, using personal identification number

### DIFF
--- a/src/main/java/no/digipost/api/client/DigipostClient.java
+++ b/src/main/java/no/digipost/api/client/DigipostClient.java
@@ -35,9 +35,11 @@ import no.digipost.api.client.representations.Identification;
 import no.digipost.api.client.representations.IdentificationResult;
 import no.digipost.api.client.representations.Link;
 import no.digipost.api.client.representations.Message;
+import no.digipost.api.client.representations.PersonalIdentificationNumber;
 import no.digipost.api.client.representations.Recipients;
-import no.digipost.api.client.representations.accounts.UserAccount;
 import no.digipost.api.client.representations.accounts.Tag;
+import no.digipost.api.client.representations.accounts.Tags;
+import no.digipost.api.client.representations.accounts.UserAccount;
 import no.digipost.api.client.representations.accounts.UserInformation;
 import no.digipost.api.client.representations.archive.Archive;
 import no.digipost.api.client.representations.archive.ArchiveDocument;
@@ -305,6 +307,10 @@ public class DigipostClient {
 
     public void removeTag(Tag tag) {
         tagApi.removeTag(tag);
+    }
+
+    public Tags getTags(PersonalIdentificationNumber personalIdentificationNumber) {
+        return tagApi.getTags(personalIdentificationNumber);
     }
 
     public ArchiveApi.ArchivingDocuments archiveDocuments(final Archive archive) {

--- a/src/main/java/no/digipost/api/client/internal/ApiServiceImpl.java
+++ b/src/main/java/no/digipost/api/client/internal/ApiServiceImpl.java
@@ -45,9 +45,11 @@ import no.digipost.api.client.representations.ErrorMessage;
 import no.digipost.api.client.representations.Identification;
 import no.digipost.api.client.representations.Link;
 import no.digipost.api.client.representations.MayHaveSender;
+import no.digipost.api.client.representations.PersonalIdentificationNumber;
 import no.digipost.api.client.representations.Recipients;
-import no.digipost.api.client.representations.accounts.UserAccount;
 import no.digipost.api.client.representations.accounts.Tag;
+import no.digipost.api.client.representations.accounts.Tags;
+import no.digipost.api.client.representations.accounts.UserAccount;
 import no.digipost.api.client.representations.accounts.UserInformation;
 import no.digipost.api.client.representations.archive.Archive;
 import no.digipost.api.client.representations.archive.ArchiveDocument;
@@ -485,6 +487,13 @@ public class ApiServiceImpl implements MessageDeliveryApi, InboxApi, DocumentApi
         } catch (IOException e) {
             throw new DigipostClientException(ErrorCode.GENERAL_ERROR, e);
         }
+    }
+
+    @Override
+    public Tags getTags(PersonalIdentificationNumber personalIdentificationNumber) {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("personal-identification-number", personalIdentificationNumber.asString());
+        return getEntity(Tags.class, getEntryPoint().getTagsUri().getPath(), queryParams);
     }
     
     private static String pathWithQuery(URI uri){

--- a/src/main/java/no/digipost/api/client/representations/EntryPoint.java
+++ b/src/main/java/no/digipost/api/client/representations/EntryPoint.java
@@ -108,6 +108,8 @@ public class EntryPoint extends Representation {
 
     public URI getRemoveTagUri() { return getLinkByRelationName(REMOVE_TAG).getUri(); }
 
+    public URI getTagsUri() { return getLinkByRelationName(GET_TAGS).getUri(); }
+
     public URI getCreateOrActivateUserAccountUri() { return getLinkByRelationName(CREATE_OR_ACTIVATE_USER_ACCOUNT).getUri(); }
 
     public String getCertificate() {

--- a/src/main/java/no/digipost/api/client/representations/Relation.java
+++ b/src/main/java/no/digipost/api/client/representations/Relation.java
@@ -51,5 +51,6 @@ public enum Relation {
     CREATE_OR_ACTIVATE_USER_ACCOUNT,
     ADD_TAG,
     REMOVE_TAG,
+    GET_TAGS,
 
 }

--- a/src/main/java/no/digipost/api/client/representations/accounts/TagType.java
+++ b/src/main/java/no/digipost/api/client/representations/accounts/TagType.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.representations.accounts;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(name = "tag-type")
+@XmlEnum
+public enum TagType {
+    PUBLIC_MAILBOX_TAG;
+
+    public String value() {
+        return name();
+    }
+
+    public static TagType fromValue(String v) {
+        return valueOf(v);
+    }
+}

--- a/src/main/java/no/digipost/api/client/representations/accounts/Tags.java
+++ b/src/main/java/no/digipost/api/client/representations/accounts/Tags.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.client.representations.accounts;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.ArrayList;
+import java.util.List;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "tags", propOrder = { "tags" })
+@XmlRootElement(name = "tags")
+public class Tags {
+
+    @XmlElement(name = "tag-type")
+    protected List<TagType> tags = new ArrayList<>();
+
+    public Tags() {
+    }
+
+    public Tags(List<TagType> tags) {
+        this.tags = tags;
+    }
+
+    public List<TagType> getTags() {
+        return tags;
+    }
+}

--- a/src/main/java/no/digipost/api/client/tag/TagApi.java
+++ b/src/main/java/no/digipost/api/client/tag/TagApi.java
@@ -15,7 +15,9 @@
  */
 package no.digipost.api.client.tag;
 
+import no.digipost.api.client.representations.PersonalIdentificationNumber;
 import no.digipost.api.client.representations.accounts.Tag;
+import no.digipost.api.client.representations.accounts.Tags;
 
 /**
  * Klasser som implementerer dette interfacet håndterer det å sette og fjerne
@@ -29,5 +31,7 @@ public interface TagApi {
     void addTag(Tag tag);
 
     void removeTag(Tag tag);
+
+    Tags getTags(PersonalIdentificationNumber personalIdentificationNumber);
 
 }

--- a/src/main/resources/xsd/api_v8.xsd
+++ b/src/main/resources/xsd/api_v8.xsd
@@ -1399,4 +1399,37 @@
         </xsd:sequence>
     </xsd:complexType>
 
+    <xsd:element name="tags" type="tags" />
+
+    <xsd:complexType name="tags">
+        <xsd:annotation>
+            <xsd:appinfo>
+                <annox:annotate target="class">
+                    <annox:annotate annox:class="javax.xml.bind.annotation.XmlRootElement" name="tags"/>
+                </annox:annotate>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="tag-type" type="tag-type" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:simpleType name="tag-type">
+        <xsd:annotation>
+            <xsd:appinfo>
+                <jaxb:typesafeEnumClass />
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="PUBLIC_MAILBOX_TAG">
+                <xsd:annotation>
+                    <xsd:documentation>The account receives public mail through Digipost.</xsd:documentation>
+                    <xsd:appinfo>
+                        <jaxb:typesafeEnumMember name="PUBLIC_MAILBOX_TAG" />
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
 </xsd:schema>


### PR DESCRIPTION
Using this feature requires the ADMINISTER_TAGS Digipost API permission. It can be used to list all current tags for a user, which as for now only covers whether the user receives public mail or not. Filter the resulting list using the TagType enum to derive desired user properties. This functionality is as of yet primarily used for Digdir/KRR to manage public mail recipients.