### PR TITLE
Don't remove digipost id from print messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>2.2</version>

--- a/src/main/java/no/digipost/api/client/internal/delivery/DocumentsPreparer.java
+++ b/src/main/java/no/digipost/api/client/internal/delivery/DocumentsPreparer.java
@@ -66,10 +66,6 @@ class DocumentsPreparer {
 
         final Map<Document, InputStream> prepared = new LinkedHashMap<>();
 
-        if(message.recipient.hasPrintDetails() && message.recipient.hasDigipostIdentification()){
-            throw new IllegalStateException("Forventet message med enkelt kanal");
-        }
-
         for (Document document : (Iterable<Document>) documentsAndContent.keySet().stream().sorted(message.documentOrder())::iterator) {
             if (document.willBeEncrypted()) {
                 byte[] byteContent = toByteArray(documentsAndContent.get(document));

--- a/src/main/java/no/digipost/api/client/internal/delivery/MessageDeliverer.java
+++ b/src/main/java/no/digipost/api/client/internal/delivery/MessageDeliverer.java
@@ -37,6 +37,7 @@ import no.digipost.api.client.security.DigipostPublicKey;
 import no.digipost.api.client.security.Encrypter;
 import no.digipost.print.validate.PdfValidator;
 import no.digipost.sanitizing.HtmlValidator;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -304,7 +305,7 @@ public class MessageDeliverer {
 
     static Message setMapAndMessageToPrint(Message messageToCopy, Map<UUID, DocumentContent> documentsAndContent,
                                            Map<Document, InputStream> documentsAndInputStream) {
-        Message singleChannelMessage = Message.copyMessageWithOnlyPrintDetails(messageToCopy);
+        Message singleChannelMessage = Message.copyPrintMessage(messageToCopy);
         setPrintContentToUUID(documentsAndContent, documentsAndInputStream, singleChannelMessage.getAllDocuments());
 
         return singleChannelMessage;

--- a/src/main/java/no/digipost/api/client/representations/Message.java
+++ b/src/main/java/no/digipost/api/client/representations/Message.java
@@ -235,26 +235,38 @@ public class Message implements MayHaveSender {
         this.batch = batch;
     }
 
-    public static Message copyMessageWithOnlyPrintDetails(Message messageToCopy){
+    /**
+     * Copies a message and forces all its documents to have file type of PDF.
+     *
+     * @param messageToCopy message to copy
+     * @return a copy of <code>messageToCopy</code>
+     */
+    public static Message copyPrintMessage(Message messageToCopy){
         List<Document> tmpAttachments = new ArrayList<>();
         for(Document attachment : messageToCopy.attachments){
             tmpAttachments.add(attachment.copyDocumentAndSetDigipostFileTypeToPdf());
         }
-
-        return new Message(messageToCopy.messageId, messageToCopy.senderId, messageToCopy.senderOrganization,
-                null, null, null, null, messageToCopy.deliveryTime, messageToCopy.invoiceReference,
-                messageToCopy.primaryDocument.copyDocumentAndSetDigipostFileTypeToPdf(), tmpAttachments, messageToCopy.recipient.getPrintDetails(), 
-                null, null, null, null, null, messageToCopy.batch);
+        return copyMessage(
+                messageToCopy, messageToCopy.primaryDocument.copyDocumentAndSetDigipostFileTypeToPdf(), tmpAttachments,
+                messageToCopy.recipient.getPrintDetails()
+        );
     }
 
     public static Message copyMessageWithOnlyDigipostDetails(Message messageToCopy){
-        return new Message(messageToCopy.messageId, messageToCopy.senderId, messageToCopy.senderOrganization,
+        return copyMessage(messageToCopy, messageToCopy.primaryDocument, messageToCopy.attachments, null);
+    }
+
+    private static Message copyMessage(Message messageToCopy, Document newPrimaryDocument, List<Document> newAttachments, PrintDetails newPrintDetails) {
+        return new Message(
+                messageToCopy.messageId, messageToCopy.senderId, messageToCopy.senderOrganization,
                 messageToCopy.recipient.nameAndAddress, messageToCopy.recipient.digipostAddress,
                 messageToCopy.recipient.personalIdentificationNumber, messageToCopy.recipient.organisationNumber,
-                messageToCopy.deliveryTime, messageToCopy.invoiceReference, messageToCopy.primaryDocument,
-                messageToCopy.attachments, null, messageToCopy.recipient.bankAccountNumber,
-                messageToCopy.printIfUnread, messageToCopy.printIfNotRegistered, messageToCopy.recipient.peppolAddresses, messageToCopy.recipient.emailDetails,
-                messageToCopy.batch);
+                messageToCopy.deliveryTime, messageToCopy.invoiceReference,
+                newPrimaryDocument, newAttachments,
+                newPrintDetails, messageToCopy.recipient.bankAccountNumber,
+                messageToCopy.printIfUnread, messageToCopy.printIfNotRegistered,
+                messageToCopy.recipient.peppolAddresses, messageToCopy.recipient.emailDetails, messageToCopy.batch
+        );
     }
 
     private Message(final String messageId, final Long senderId, final SenderOrganization senderOrganization,

--- a/src/test/java/no/digipost/api/client/representations/MessageTest.java
+++ b/src/test/java/no/digipost/api/client/representations/MessageTest.java
@@ -16,6 +16,7 @@
 package no.digipost.api.client.representations;
 
 import no.digipost.api.client.SenderId;
+
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
@@ -45,6 +46,7 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -96,13 +98,13 @@ public class MessageTest {
                         new PrintRecipient("Test", new NorwegianAddress("Bajs", "Korv", "Zip", "Zop")),
                         PrintDetails.PrintColors.COLORS, PrintDetails.NondeliverableHandling.RETURN_TO_SENDER))).build();
 
-        Message copyOfMessageWithPrintDetailsOnly = Message.copyMessageWithOnlyPrintDetails(message);
+        Message copyOfMessageWithPrintDetailsOnly = Message.copyPrintMessage(message);
 
         assertThat(copyOfMessageWithPrintDetailsOnly.deliveryTime, is(message.deliveryTime));
         assertThat(copyOfMessageWithPrintDetailsOnly.invoiceReference, is(message.invoiceReference));
         assertThat(copyOfMessageWithPrintDetailsOnly.messageId, is(message.messageId));
         assertThat(copyOfMessageWithPrintDetailsOnly.senderId, is(message.senderId));
-        assertNull(copyOfMessageWithPrintDetailsOnly.recipient.digipostAddress);
+        assertNotNull(copyOfMessageWithPrintDetailsOnly.recipient.digipostAddress);
         assertNull(copyOfMessageWithPrintDetailsOnly.recipient.nameAndAddress);
         assertNull(copyOfMessageWithPrintDetailsOnly.recipient.organisationNumber);
         assertNull(copyOfMessageWithPrintDetailsOnly.recipient.personalIdentificationNumber);


### PR DESCRIPTION
This fixes a bug where all ids (digipost address, pin, name and addres and organisation number) gets removed before sending to the api. The result was that the API got a direct print message, even if it was originally a print fallback message, thus returning errors if the sender was not allowed to use direct print.

(Message.copyMessageWithOnlyPrintDetails,
MessageDeliverer.setMapAndMessageToPrint) Copy all fields of the input message (was: omitting ids and a few other fields). Rename to copyPrintMessage, since it no longer narrows the result to print details. Doc fix.