### PR TITLE
Add missing values for enum Channel

### DIFF
--- a/src/main/java/no/digipost/api/client/representations/Channel.java
+++ b/src/main/java/no/digipost/api/client/representations/Channel.java
@@ -22,5 +22,8 @@ import javax.xml.bind.annotation.XmlType;
 @XmlEnum
 public enum Channel {
     PRINT,
-    DIGIPOST;
+    DIGIPOST,
+    PEPPOL,
+    EPOST,
+    PENDING;
 }


### PR DESCRIPTION
The values PEPPOL, EPOST and PENDING are possible according to the XSD, but the representation class does not reflect this.