### PR TITLE
Make identification of recipients optional for fallback print messages

### DIFF
--- a/src/main/java/no/digipost/api/client/delivery/OngoingDelivery.java
+++ b/src/main/java/no/digipost/api/client/delivery/OngoingDelivery.java
@@ -87,6 +87,18 @@ public interface OngoingDelivery<OPERATIONS extends OngoingDelivery<OPERATIONS> 
         default SendableWithPrintFallback addContent(Document document, byte[] content, byte[] printContent) {
             return addContent(document, new ByteArrayInputStream(content), new ByteArrayInputStream(printContent));
         }
+
+        /**
+         * Send uten å prøve å identifisere mottakeren først.
+         *
+         * <p>
+         * Unngår unødvendig prosessering dersom du allerede har
+         * identifisert mottakeren.
+         * </p>
+         *
+         * @return videre operasjoner for å fullføre leveransen.
+         */
+        MessageDelivery sendUnidentified();
     }
 
 

--- a/src/main/java/no/digipost/api/client/internal/delivery/PrintOnlyMessage.java
+++ b/src/main/java/no/digipost/api/client/internal/delivery/PrintOnlyMessage.java
@@ -60,7 +60,7 @@ final class PrintOnlyMessage implements OngoingDelivery.SendableForPrintOnly {
 
     @Override
     public MessageDelivery send() {
-        return sender.sendMultipartMessage(printMessage, documents);
+        return sender.sendMultipartMessage(printMessage, documents, false);
     }
 
 }

--- a/src/main/java/no/digipost/api/client/internal/delivery/WithPrintFallback.java
+++ b/src/main/java/no/digipost/api/client/internal/delivery/WithPrintFallback.java
@@ -62,7 +62,12 @@ final class WithPrintFallback implements OngoingDelivery.SendableWithPrintFallba
 
     @Override
     public MessageDelivery send() {
-        return sender.sendMultipartMessage(message, documents);
+        return sender.sendMultipartMessage(message, documents, true);
+    }
+
+    @Override
+    public MessageDelivery sendUnidentified() {
+        return sender.sendMultipartMessage(message, documents, false);
     }
 }
 


### PR DESCRIPTION
by adding the method, sendUnidentified, in the interface OngoingDelivery.SendableWithPrintFallback.

(WithPrintFallback.sendUnidentified, send, PrintOnlyMessage.send, MessageDeliverer) New parameter to toggle indentification of recipients, shouldIdentifyRecipient. Omit identification when the parameter is false.