### PR TITLE
Add guard to remove a possible NullpointerException

### DIFF
--- a/src/main/java/no/digipost/api/client/representations/sender/SenderInformation.java
+++ b/src/main/java/no/digipost/api/client/representations/sender/SenderInformation.java
@@ -95,6 +95,7 @@ public class SenderInformation
     }
 
     public SenderFeature get(SenderFeatureName featureName) {
+        if (supportedFeatures == null) return null;
         for (SenderFeature feature : supportedFeatures ){
             if (featureName.equals(feature.getName())) {
                 return feature;

--- a/src/test/java/no/digipost/api/client/representations/sender/SenderInformationTest.java
+++ b/src/test/java/no/digipost/api/client/representations/sender/SenderInformationTest.java
@@ -26,13 +26,14 @@ import static no.digipost.api.client.representations.sender.SenderFeatureName.DI
 import static no.digipost.api.client.representations.sender.SenderStatus.NO_INFO_AVAILABLE;
 import static no.digipost.api.client.representations.sender.SenderStatus.VALID_SENDER;
 import static org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SenderInformationTest {
 
     @Test
     public void marshallValidateXmlAndUnmarshall() {
-        SenderInformation senderInformation = new SenderInformation(null, NO_INFO_AVAILABLE, Collections.<SenderFeature>emptyList());
+        SenderInformation senderInformation = new SenderInformation(null, NO_INFO_AVAILABLE, Collections.emptyList());
         SenderInformation unmarshalled = marshallValidateAndUnmarshall(senderInformation);
         assertTrue(reflectionEquals(senderInformation, unmarshalled));
 
@@ -41,4 +42,11 @@ public class SenderInformationTest {
         assertTrue(reflectionEquals(senderInformation, unmarshalled));
     }
 
+
+    @Test
+    void shouldNotCauseNullpointerException() {
+        SenderInformation senderInformation = new SenderInformation(null, NO_INFO_AVAILABLE, Collections.emptyList());
+        assertFalse(senderInformation.hasEnabled(DIGIPOST_DELIVERY));
+        System.out.println(senderInformation);
+    }
 }


### PR DESCRIPTION
When supportedFeatures == null the for loop will cause a NpE. This happens if NO_INFO_AVAILABLE is the SenderStatus.

This a usage of `sendClient.getSenderInformation(SenderId.of(1030)).hasEnabled(SenderFeatureName.DIGIPOST_DELIVERY);` could result in NpE instead of `false` as would be expected