### PR TITLE
Add error code to indicate batch not found

### DIFF
--- a/src/main/java/no/digipost/api/client/errorhandling/ErrorCode.java
+++ b/src/main/java/no/digipost/api/client/errorhandling/ErrorCode.java
@@ -122,6 +122,7 @@ public enum ErrorCode {
     PEPPOL_ERROR(CLIENT_DATA),
     PEPPOL_FILE_MUST_BE_XML(CLIENT_DATA),
     UNKNOWN_PEPPOL_RECIPIENT(CLIENT_DATA),
+    UNKNOWN_BATCH(CLIENT_DATA),
     ;
 
     private static final Map<String, ErrorCode> errorByName = new HashMap<>(); static {


### PR DESCRIPTION
This eliminates the need to parse the error message from a general error, when the api returns an error on a non-existing batch.