### PR TITLE
Add ErrorCode returned from the API when accessing resources with unknown users in request body

### DIFF
--- a/src/main/java/no/digipost/api/client/errorhandling/ErrorCode.java
+++ b/src/main/java/no/digipost/api/client/errorhandling/ErrorCode.java
@@ -123,6 +123,7 @@ public enum ErrorCode {
     PEPPOL_FILE_MUST_BE_XML(CLIENT_DATA),
     UNKNOWN_PEPPOL_RECIPIENT(CLIENT_DATA),
     UNKNOWN_BATCH(CLIENT_DATA),
+    UNKNOWN_USER(CLIENT_DATA),
     ;
 
     private static final Map<String, ErrorCode> errorByName = new HashMap<>(); static {


### PR DESCRIPTION
This is _not_ the same as `UNKNOWN_USER_ID`, which is used when the `X_Digipost_UserId` header is missing.