### PR TITLE
Update docs on Norwegian defaulting of phone number

### DIFF
--- a/docs/_v16_x/2_send.md
+++ b/docs/_v16_x/2_send.md
@@ -341,6 +341,8 @@ client.stopSharing(senderId, sharedDocumentsRequestState.stopSharing())
 
 It is possible to send a message to a person, who does not have a Digipost account, where the message triggers an SMS notification with a request for registration. The SMS notification says that if they register for a Digipost account the document will be delivered digitally. The actual content of the SMS notification is set manually by Digipost. If the user does not register for a Digipost account within the defined deadline, the document will either be delivered as physical mail or not at all.
 
+The phone number provided SHOULD include the country code (i.e. +47). If the phone number does not start with either `"+"`, `"00"` or `"011"`, we will prepend `"+47"` if and only if the phone number string is 8 characters long. If this is not the case, the request is rejected.
+
 ### Request for registration with physical mail as fallback
 
 In this case the document will be delivered as physical mail if the recipient has not registered for a Digipost account by the defined deadline.


### PR DESCRIPTION
The treatment of phone numbers in "request for registration" is now less strict to accomodate for the common scenario of using Norwegian phone numbers without a country code prefix.