### PR TITLE
Bundle med ruby 3 og bump activesupport

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 require 'json'
 require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
+versions = JSON.parse(OpenURI.open_uri('https://pages.github.com/versions.json').read)
 
 gem 'github-pages', versions['github-pages'], group: :jekyll_plugins
+gem 'activesupport', '~> 7.1', '>= 7.1.3'
+gem "webrick", "~> 1.8"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -42,9 +42,9 @@ GEM
     ffi (1.16.3)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
-    github-pages (229)
+    github-pages (231)
       github-pages-health-check (= 1.18.2)
-      jekyll (= 3.9.4)
+      jekyll (= 3.9.5)
       jekyll-avatar (= 0.8.0)
       jekyll-coffeescript (= 1.2.2)
       jekyll-commonmark-ghpages (= 0.4.0)
@@ -58,7 +58,7 @@ GEM
       jekyll-paginate (= 1.1.0)
       jekyll-readme-index (= 0.3.0)
       jekyll-redirect-from (= 0.16.0)
-      jekyll-relative-links (= 0.7.0)
+      jekyll-relative-links (= 0.6.1)
       jekyll-remote-theme (= 0.4.3)
       jekyll-sass-converter (= 1.5.2)
       jekyll-seo-tag (= 2.8.0)
@@ -99,7 +99,7 @@ GEM
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    jekyll (3.9.4)
+    jekyll (3.9.5)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -145,7 +145,7 @@ GEM
       jekyll (>= 3.0, < 5.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
-    jekyll-relative-links (0.7.0)
+    jekyll-relative-links (0.6.1)
       jekyll (>= 3.3, < 5.0)
     jekyll-remote-theme (0.4.3)
       addressable (~> 2.0)
@@ -223,10 +223,10 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.22.2)
     mutex_m (0.2.0)
-    nokogiri (1.15.5)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.15.5-x86_64-darwin)
+    nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -263,13 +263,16 @@ GEM
       unf_ext
     unf_ext (0.0.9.1)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
   x86_64-darwin-21
 
 DEPENDENCIES
-  github-pages (= 229)
+  activesupport (~> 7.1, >= 7.1.3)
+  github-pages (= 231)
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.4.12


### PR DESCRIPTION
Måtte skrive om open() i Gemfile for å matche ruby 3 syntaks. La til activesupport eksplisitt fordi den downgradet seg ved oppdatering til ruby 3.3.0. Nokogiri er også oppdatert for å patche en CVE.