### PR TITLE
Hent path uten å hente query params

### DIFF
--- a/src/main/java/no/digipost/api/client/internal/ApiServiceImpl.java
+++ b/src/main/java/no/digipost/api/client/internal/ApiServiceImpl.java
@@ -609,17 +609,12 @@ public class ApiServiceImpl implements MessageDeliveryApi, InboxApi, DocumentApi
 
     private HttpClientResponseHandler<CloseableHttpResponse> responseHandler() {
         return response -> {
-            if (response.getCode() / 100 == 2) {
                 if (response instanceof CloseableHttpResponse) {
                     return (CloseableHttpResponse) response;
                 } else {
                     throw new DigipostClientException(ErrorCode.GENERAL_ERROR,
                             "Expected response to be instance of CloseableHttpResponse, but got " + response.getClass().getName());
                 }
-            } else {
-                ErrorMessage errorMessage = unmarshal(jaxbContext, response.getEntity().getContent(), ErrorMessage.class);
-                throw new DigipostClientException(errorMessage);
-            }
         };
     }
 }

--- a/src/main/java/no/digipost/api/client/internal/http/request/interceptor/ApacheHttpRequestToSign.java
+++ b/src/main/java/no/digipost/api/client/internal/http/request/interceptor/ApacheHttpRequestToSign.java
@@ -48,8 +48,12 @@ final class ApacheHttpRequestToSign implements RequestToSign {
 
     @Override
     public String getPath() {
-        String path = clientRequest.getPath();
-        return path != null ? path : "";
+        try {
+            String path = clientRequest.getUri().getPath();
+            return path != null ? path : "";
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
     }
 
     @Override

--- a/src/main/java/no/digipost/api/client/internal/http/response/HttpResponseUtils.java
+++ b/src/main/java/no/digipost/api/client/internal/http/response/HttpResponseUtils.java
@@ -28,6 +28,7 @@ import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.StatusLine;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -92,10 +93,7 @@ public final class HttpResponseUtils {
     }
 
     private static ErrorMessage fetchErrorMessageString(final HttpResponse response, final HttpEntity responseEntity) {
-        String statusLine = response.getVersion() + " " + response.getCode();
-        if (StringUtils.isNotBlank(response.getReasonPhrase())) {
-            statusLine += " " + response.getReasonPhrase();
-        }
+        StatusLine statusLine = new StatusLine(response);
         final ErrorType errorType = ErrorType.fromResponseStatus(response.getCode());
         if (responseEntity == null) {
             return new ErrorMessage(errorType, "status=" + statusLine + ", body=<empty>");

--- a/src/main/java/no/digipost/api/client/internal/http/response/interceptor/ApacheHttpResponseToVerify.java
+++ b/src/main/java/no/digipost/api/client/internal/http/response/interceptor/ApacheHttpResponseToVerify.java
@@ -49,6 +49,11 @@ final class ApacheHttpResponseToVerify implements ResponseToVerify {
 
     @Override
     public String getPath() {
-        return (String) context.getAttribute("request-path");
+        String pathWithQueryParams = (String) context.getAttribute("request-path");
+        int indexOfQuestionMark = pathWithQueryParams.indexOf('?');
+        if (indexOfQuestionMark != -1) {
+           return pathWithQueryParams.substring(0, indexOfQuestionMark);
+        }
+        return pathWithQueryParams;
     }
 }


### PR DESCRIPTION
`getPath` directly get the path with query params which is not the same
as the old behavior.
Were doing error handling inside the response handler. This is not
needed as correct error handling is done outside