### PR TITLE
Preserve content-encoding in response content interceptor

### DIFF
--- a/src/main/java/no/digipost/api/client/internal/http/response/interceptor/ResponseContentSHA256Interceptor.java
+++ b/src/main/java/no/digipost/api/client/internal/http/response/interceptor/ResponseContentSHA256Interceptor.java
@@ -52,7 +52,7 @@ public class ResponseContentSHA256Interceptor implements HttpResponseInterceptor
                                     X_Content_SHA256, response.getCode())));
             byte[] entityBytes = EntityUtils.toByteArray(entity);
             validerBytesMotHashHeader(hashHeaderValue, entityBytes);
-            classicHttpResponse.setEntity(new ByteArrayEntity(entityBytes, ContentType.parse(entityDetails.getContentType())));
+            classicHttpResponse.setEntity(new ByteArrayEntity(entityBytes, ContentType.parse(entityDetails.getContentType()), entityDetails.getContentEncoding()));
         }
     }
 


### PR DESCRIPTION
This solves issues with gzip encoded content where the encoding was missing after the interceptor. This has to be handled in apache http v5 because ByteArrayEntity now requires a non null content encoding to make sure the encoding is preserved. Apache will decompress the gzip automaticalyly if content encoding is set to gzip.